### PR TITLE
refactor: Move common implementation to runtime-common

### DIFF
--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -123,7 +123,10 @@ pub fn create_benchmark_extrinsic(
 	let best_hash = client.chain_info().best_hash;
 	let best_block = client.chain_info().best_number;
 
-	let period = BLOCK_HASH_COUNT.checked_next_power_of_two().map(|c| c / 2).unwrap_or(2) as u64;
+	let period = runtime::common::BlockHashCount::get()
+		.checked_next_power_of_two()
+		.map(|c| c / 2)
+		.unwrap_or(2) as u64;
 	let extra: runtime::SignedExtra = (
 		frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
 		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -3,15 +3,22 @@ name = "noir-runtime-common"
 version = "0.4.0"
 authors = ["Haderech Pte. Ltd."]
 edition = "2021"
-license = "Apache-2.0"
+license = "GPL-3.0-or-later"
 repository = "https://github.com/noirhq/noir.git"
 publish = false
 
 [dependencies]
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
 noir-core-primitives = { workspace = true }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+static_assertions = "1.1"
 
 [features]
 default = ["std"]
 std = [
+	"frame-support/std",
+	"frame-system/std",
 	"noir-core-primitives/std",
+	"pallet-transaction-payment/std",
 ]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,46 +1,69 @@
 // This file is part of Noir.
 
 // Copyright (c) Haderech Pte. Ltd.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: GPL-3.0-or-later
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
-// 	http://www.apache.org/licenses/LICENSE-2.0
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Common implementation across Noir runtimes.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[allow(non_upper_case_globals)]
-pub mod units {
-	use noir_core_primitives::{Balance, Moment};
+pub mod units;
 
-	/// A unit of base currency.
-	pub const DOLLARS: Balance = 1_000_000_000_000_000_000;
-	/// One hundredth of a dollar.
-	pub const CENTS: Balance = DOLLARS / 100;
+use crate::units::MiB;
+use frame_support::{
+	parameter_types,
+	sp_runtime::{traits::Bounded, FixedPointNumber, Perbill, Perquintill},
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
+use frame_system::limits;
+use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
+use static_assertions::const_assert;
 
-	/// Kibibytes.
-	pub const KiB: u32 = 1024;
-	/// Mebibytes.
-	pub const MiB: u32 = 1024 * KiB;
+/// Assumes that 1% of the block weight is used for initialization.
+pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(1);
+/// 75% of the block weight is used for `Normal` extrinsics.
+pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+/// 2 seconds for block computation with 6-second average block time.
+pub const MAXIMUM_BLOCK_WEIGHT: Weight =
+	Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
 
-	/// A day in milliseconds.
-	pub const DAYS: Moment = 24 * HOURS;
-	/// An hour in milliseconds.
-	pub const HOURS: Moment = 60 * MINUTES;
-	/// A minute in milliseconds.
-	pub const MINUTES: Moment = 60 * SECONDS;
-	/// A second in milliseconds.
-	pub const SECONDS: Moment = 1000;
-	/// A millisecond.
-	pub const MILLISECONDS: Moment = 1;
+const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
+
+parameter_types! {
+	/// 4096 block hashes are kept in storage.
+	pub const BlockHashCount: u32 = 4096;
+	/// The portion of `NORMAL_DISPATCH_RATIO` for adjusting fees.
+	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
+	/// Adjustment variable that how much the fee should be adjusted.
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(75, 1000_000);
+	/// Minimum amount of the multiplier. This value should be high enough to recover from the
+	/// minimum.
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 10u128);
+	/// Maximum amount of the multiplier.
+	pub MaximumMultiplier: Multiplier = Bounded::max_value();
+	/// 5 MiB block size limit.
+	pub BlockLength: limits::BlockLength =
+		limits::BlockLength::max_with_normal_ratio(5 * MiB, NORMAL_DISPATCH_RATIO);
 }
+
+/// Parameterized slow adjusting fee updated.
+pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<
+	R,
+	TargetBlockFullness,
+	AdjustmentVariable,
+	MinimumMultiplier,
+	MaximumMultiplier,
+>;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -48,7 +48,7 @@ parameter_types! {
 	/// The portion of `NORMAL_DISPATCH_RATIO` for adjusting fees.
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	/// Adjustment variable that how much the fee should be adjusted.
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(75, 1000_000);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(75, 1_000_000);
 	/// Minimum amount of the multiplier. This value should be high enough to recover from the
 	/// minimum.
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 10u128);

--- a/runtime/common/src/units.rs
+++ b/runtime/common/src/units.rs
@@ -1,0 +1,42 @@
+// This file is part of Noir.
+
+// Copyright (c) Haderech Pte. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(non_upper_case_globals)]
+
+use noir_core_primitives::{Balance, Moment};
+
+/// A unit of base currency.
+pub const DOLLARS: Balance = 1_000_000_000_000_000_000;
+/// One hundredth of a dollar.
+pub const CENTS: Balance = DOLLARS / 100;
+
+/// Kibibytes.
+pub const KiB: u32 = 1024;
+/// Mebibytes.
+pub const MiB: u32 = 1024 * KiB;
+
+/// A day in milliseconds.
+pub const DAYS: Moment = 24 * HOURS;
+/// An hour in milliseconds.
+pub const HOURS: Moment = 60 * MINUTES;
+/// A minute in milliseconds.
+pub const MINUTES: Moment = 60 * SECONDS;
+/// A second in milliseconds.
+pub const SECONDS: Moment = 1000;
+/// A millisecond.
+pub const MILLISECONDS: Moment = 1;

--- a/runtime/solochain/src/configs/evm.rs
+++ b/runtime/solochain/src/configs/evm.rs
@@ -18,7 +18,7 @@
 
 use crate::*;
 
-use super::system::NORMAL_DISPATCH_RATIO;
+use common::NORMAL_DISPATCH_RATIO;
 use fp_evm::weight_per_gas;
 use frame_babel::ethereum::{AddressMapping, EnsureAddress, FrontierPrecompiles};
 use frame_support::weights::Weight;

--- a/runtime/solochain/src/configs/system.rs
+++ b/runtime/solochain/src/configs/system.rs
@@ -18,27 +18,20 @@
 
 use crate::*;
 
-use common::units::MiB;
+use common::{
+	BlockHashCount, BlockLength, AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT,
+	NORMAL_DISPATCH_RATIO,
+};
 use frame_support::{
 	derive_impl,
 	dispatch::DispatchClass,
 	traits::ConstU32,
-	weights::constants::{
-		BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND,
-	},
+	weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
 };
 use frame_system::{config_preludes::SolochainDefaultConfig, limits};
-use sp_runtime::{traits::AccountIdLookup, Perbill};
-
-pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(1);
-pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-pub const MAXIMUM_BLOCK_WEIGHT: Weight =
-	Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
+use sp_runtime::traits::AccountIdLookup;
 
 parameter_types! {
-	pub const BlockHashCount: u32 = super::BLOCK_HASH_COUNT;
-	pub BlockLength: limits::BlockLength = limits::BlockLength
-		::max_with_normal_ratio(5 * MiB, NORMAL_DISPATCH_RATIO);
 	pub BlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
 		.base_block(BlockExecutionWeight::get())
 		.for_class(DispatchClass::all(), |weights| {

--- a/runtime/solochain/src/configs/transaction_payment.rs
+++ b/runtime/solochain/src/configs/transaction_payment.rs
@@ -18,32 +18,19 @@
 
 use crate::*;
 
-use common::units::CENTS;
+use common::{units::CENTS, SlowAdjustingFeeUpdate};
 use frame_support::weights::{
 	constants::ExtrinsicBaseWeight, ConstantMultiplier, WeightToFeeCoefficient,
 	WeightToFeeCoefficients, WeightToFeePolynomial,
 };
-use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_transaction_payment::FungibleAdapter;
 use smallvec::smallvec;
-use sp_runtime::{traits::Bounded, FixedPointNumber, Perbill, Perquintill};
+use sp_runtime::Perbill;
 
 parameter_types! {
 	pub const OperationalFeeMultiplier: u8 = 5;
 	pub const TransactionByteFee: Balance = (1 * CENTS) / 100;
-
-	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(75, 1_000_000);
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 10u128);
-	pub MaximumMultiplier: Multiplier = Bounded::max_value();
 }
-
-pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<
-	R,
-	TargetBlockFullness,
-	AdjustmentVariable,
-	MinimumMultiplier,
-	MaximumMultiplier,
->;
 
 pub struct WeightToFee;
 

--- a/runtime/solochain/src/lib.rs
+++ b/runtime/solochain/src/lib.rs
@@ -36,7 +36,7 @@ pub use primitives::*;
 pub use version::*;
 
 use alloc::vec::Vec;
-use frame_support::{parameter_types, weights::Weight};
+use frame_support::parameter_types;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_version::RuntimeVersion;
 


### PR DESCRIPTION
This PR moves common implementation to `noir-runtime-common` crate.