### PR TITLE
refactor: Use EncodeLike args for Multimap traits

### DIFF
--- a/frame/babel/src/cosmos/address.rs
+++ b/frame/babel/src/cosmos/address.rs
@@ -45,7 +45,7 @@ where
 	T: pallet_cosmwasm::Config + unify_account::Config,
 {
 	fn convert(account: AccountIdOf<T>) -> String {
-		let addresses = T::AddressMap::get(account.clone());
+		let addresses = T::AddressMap::get(&account);
 		let address: Option<&CosmosAddress> = addresses.iter().find_map(|address| match address {
 			VarAddress::Cosmos(address) => Some(address),
 			_ => None,

--- a/frame/babel/src/extensions/unify_account.rs
+++ b/frame/babel/src/extensions/unify_account.rs
@@ -63,7 +63,7 @@ impl<T: Config> UnifyAccount<T> {
 				let address = EthereumAddress::from(public);
 				let interim = address.clone().into_account_truncating();
 				T::DrainBalance::drain_balance(&interim, who)?;
-				T::AddressMap::try_insert(who.clone(), VarAddress::Ethereum(address))
+				T::AddressMap::try_insert(who, VarAddress::Ethereum(address))
 					.map_err(|_| "account unification failed: ethereum")?;
 			}
 			#[cfg(feature = "cosmos")]
@@ -71,7 +71,7 @@ impl<T: Config> UnifyAccount<T> {
 				let address = CosmosAddress::from(public);
 				let interim = address.clone().into_account_truncating();
 				T::DrainBalance::drain_balance(&interim, who)?;
-				T::AddressMap::try_insert(who.clone(), VarAddress::Cosmos(address))
+				T::AddressMap::try_insert(who, VarAddress::Cosmos(address))
 					.map_err(|_| "account unification failed: cosmos")?;
 			}
 		}

--- a/frame/babel/src/lib.rs
+++ b/frame/babel/src/lib.rs
@@ -110,7 +110,7 @@ pub mod pallet {
 			transaction: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			let address = T::AddressMap::get(who.clone())
+			let address = T::AddressMap::get(&who)
 				.iter()
 				.find_map(|address| match address {
 					VarAddress::Ethereum(address) => Some(address.clone()),


### PR DESCRIPTION
This PR refines the traits of pallet-multimap to use `EncodeLike` args.