### PR TITLE
build(deps): Bump Polkadot SDK to stable2409

### DIFF
--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 
 [dependencies]
 np-runtime = { workspace = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/babel/Cargo.toml
+++ b/frame/babel/Cargo.toml
@@ -14,39 +14,39 @@ cosmwasm-std = { workspace = true, default-features = false, optional = true }
 cosmwasm-vm = { workspace = true, default-features = false, optional = true }
 cosmwasm-vm-wasmi = { workspace = true, default-features = false, optional = true }
 ethereum = { version = "0.15.0", default-features = false, optional = true }
-fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+fp-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 hex-literal = "0.4"
 np-babel = { workspace = true, default-features = false }
 np-cosmos = { workspace = true, optional = true }
 np-ethereum = { workspace = true, optional = true }
 num_enum = { version = "0.7", default-features = false, optional = true }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false, optional = true }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false, optional = true }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 pallet-cosmos = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-types = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-x-auth-signing = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-x-bank = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-x-wasm = { workspace = true, default-features = false, optional = true }
 pallet-cosmwasm = { workspace = true, default-features = false, optional = true }
-pallet-ethereum = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
-pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
+pallet-ethereum = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
+pallet-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
 pallet-evm-precompileset-assets-erc20 = { workspace = true, optional = true }
 pallet-evm-precompile-balances-erc20 = { workspace = true, optional = true }
-pallet-evm-precompile-blake2 = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
-pallet-evm-precompile-bn128 = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
-pallet-evm-precompile-modexp = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
-pallet-evm-precompile-simple = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
+pallet-evm-precompile-blake2 = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
+pallet-evm-precompile-bn128 = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
+pallet-evm-precompile-modexp = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
+pallet-evm-precompile-simple = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
 pallet-multimap = { workspace = true, default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, optional = true }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, optional = true }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0.210", default-features = false, features = ["derive"], optional = true }
 serde-json-wasm = { version = "1.0.1", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/frame/babel/src/ethereum/precompile.rs
+++ b/frame/babel/src/ethereum/precompile.rs
@@ -23,7 +23,7 @@ use frame_support::{
 	dispatch::{DispatchClass, GetDispatchInfo, Pays, PostDispatchInfo},
 	StorageHasher, Twox128,
 };
-use pallet_evm::{AddressMapping, GasWeightMapping};
+use pallet_evm::{AddressMapping, FrameSystemAccountProvider, GasWeightMapping};
 use pallet_evm_precompile_balances_erc20::Erc20Metadata;
 use pallet_evm_precompileset_assets_erc20::AddressToAssetId;
 use parity_scale_codec::{Decode, DecodeLimit, Encode};
@@ -33,7 +33,7 @@ use sp_runtime::traits::{Dispatchable, Get};
 pub trait Config:
 	pallet_assets::Config
 	+ pallet_balances::Config
-	+ pallet_evm::Config
+	+ pallet_evm::Config<AccountProvider = FrameSystemAccountProvider<Self>>
 	+ Erc20Metadata
 	+ AddressToAssetId<Self::AssetId>
 {

--- a/frame/babel/src/lib.rs
+++ b/frame/babel/src/lib.rs
@@ -54,7 +54,7 @@ pub mod pallet {
 	};
 	use pallet_cosmos_types::address::acc_address_from_bech32;
 	use pallet_cosmos_x_auth_signing::sign_verifiable_tx::traits::SigVerifiableTx;
-	use pallet_evm::AddressMapping as _;
+	use pallet_evm::{AddressMapping as _, FrameSystemAccountProvider};
 	use pallet_multimap::traits::{UniqueMap, UniqueMultimap};
 	use sp_core::ecdsa;
 	use sp_runtime::{
@@ -72,7 +72,7 @@ pub mod pallet {
 		+ pallet_balances::Config
 		+ pallet_cosmos::Config<AssetId = <Self as pallet_assets::Config>::AssetId>
 		+ pallet_ethereum::Config
-		+ pallet_evm::Config
+		+ pallet_evm::Config<AccountProvider = FrameSystemAccountProvider<Self>>
 	{
 		type AddressMap: UniqueMultimap<Self::AccountId, VarAddress>;
 		type AssetMap: UniqueMap<AssetIdOf<Self>, DenomOf<Self>>;

--- a/frame/cosmos/Cargo.toml
+++ b/frame/cosmos/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 
 [dependencies]
 cosmos-sdk-proto = { version = "0.24", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 pallet-cosmos-x-auth-signing = { workspace = true, default-features = false }
 pallet-cosmos-types = { workspace = true, default-features = false }
 pallet-multimap = { workspace = true, default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 np-cosmos = { workspace = true, default-features = false }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/rpc/Cargo.toml
+++ b/frame/cosmos/rpc/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 cosmos-runtime-api = { workspace = true, features = ["std"] }
 futures = "0.3"
 hex = "0.4.3"
-jsonrpsee = { version = "0.23", features = ["client", "server", "macros"] }
+jsonrpsee = { version = "0.24", features = ["client", "server", "macros"] }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
 sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
 sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }

--- a/frame/cosmos/rpc/Cargo.toml
+++ b/frame/cosmos/rpc/Cargo.toml
@@ -12,8 +12,8 @@ cosmos-runtime-api = { workspace = true, features = ["std"] }
 futures = "0.3"
 hex = "0.4.3"
 jsonrpsee = { version = "0.23", features = ["client", "server", "macros"] }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }

--- a/frame/cosmos/runtime-api/Cargo.toml
+++ b/frame/cosmos/runtime-api/Cargo.toml
@@ -12,8 +12,8 @@ pallet-cosmos-types = { workspace = true, default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0.210", default-features = false, features = ["derive"] }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/types/Cargo.toml
+++ b/frame/cosmos/types/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 [dependencies]
 bech32 = { version = "0.11", default-features = false, features = ["alloc"] }
 cosmos-sdk-proto = { version = "0.24", default-features = false, features = ["cosmwasm"] }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 impl-trait-for-tuples = { version = "0.2.2" }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0.210", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [dev-dependencies]
 hex = "0.4"

--- a/frame/cosmos/x/auth/Cargo.toml
+++ b/frame/cosmos/x/auth/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 
 [dependencies]
 cosmos-sdk-proto = { version = "0.24", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 np-cosmos = { workspace = true, default-features = false }
 pallet-cosmos = { workspace = true, default-features = false }
 pallet-cosmos-types = { workspace = true, default-features = false }
 pallet-cosmos-x-auth-signing = { workspace = true, default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [dev-dependencies]
 hex = "0.4"

--- a/frame/cosmos/x/auth/signing/Cargo.toml
+++ b/frame/cosmos/x/auth/signing/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { version = "1.0.127", default-features = false }
 [dev-dependencies]
 base64ct = { version = "1.6.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/x/bank/Cargo.toml
+++ b/frame/cosmos/x/bank/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 
 [dependencies]
 cosmos-sdk-proto = { version = "0.24", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 pallet-cosmos = { workspace = true, default-features = false }
 pallet-cosmos-types = { workspace = true, default-features = false }
 pallet-cosmos-x-bank-types = { workspace = true, default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/x/wasm/Cargo.toml
+++ b/frame/cosmos/x/wasm/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 core2 = { version = "0.4.0", default-features = false, features = ["alloc"] }
 cosmos-sdk-proto = { version = "0.24", default-features = false, features = ["cosmwasm"] }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 libflate = { version = "2.1.0", default-features = false }
 log = { version = "0.4.21", default-features = false }
@@ -18,8 +18,8 @@ pallet-cosmos = { workspace = true, default-features = false }
 pallet-cosmos-types = { workspace = true, default-features = false }
 pallet-cosmos-x-wasm-types = { workspace = true, default-features = false }
 pallet-cosmwasm = { workspace = true, default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/multimap/Cargo.toml
+++ b/frame/multimap/Cargo.toml
@@ -8,13 +8,13 @@ repository = "https://github.com/noirhq/noir.git"
 publish = false
 
 [dependencies]
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false }
 scale-info = { version = "2.11", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
 
 [features]
 default = ["std"]

--- a/primitives/babel/Cargo.toml
+++ b/primitives/babel/Cargo.toml
@@ -13,7 +13,7 @@ np-ethereum = { workspace = true, default-features = false, optional = true }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std", "cosmos", "ethereum"]

--- a/primitives/cosmos/Cargo.toml
+++ b/primitives/cosmos/Cargo.toml
@@ -14,9 +14,9 @@ parity-scale-codec = { version = "3.6", default-features = false, features = ["d
 ripemd = { version = "0.1", default-features = false }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [dev-dependencies]
 const-hex = "1.12.0"

--- a/primitives/ethereum/Cargo.toml
+++ b/primitives/ethereum/Cargo.toml
@@ -14,9 +14,9 @@ k256 = { version = "0.13", default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 [dependencies]
 buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
 const-hex = { version = "1.12", default-features = false }
-fp-self-contained = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+fp-self-contained = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/noirhq/noir.git"
 publish = false
 
 [dependencies]
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 noir-core-primitives = { workspace = true }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 static_assertions = "1.1"
 
 [features]

--- a/vendor/composable/composable-support/Cargo.toml
+++ b/vendor/composable/composable-support/Cargo.toml
@@ -15,9 +15,9 @@ codec = { version = "3.6.0", package = "parity-scale-codec", default-features = 
 ] }
 num-traits = { version = "0.2.14", default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/vendor/composable/cosmwasm/Cargo.toml
+++ b/vendor/composable/cosmwasm/Cargo.toml
@@ -31,14 +31,14 @@ wasmi = { version = "0.30.0", default-features = false }
 wasm-instrument = { version = "0.4.0", default-features = false }
 wasmi-validation = { version = "0.5.0", default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 composable-support = { workspace = true, default-features = false }
 cosmwasm-std = { workspace = true, default-features = false, features = [

--- a/vendor/composable/cosmwasm/rpc/Cargo.toml
+++ b/vendor/composable/cosmwasm/rpc/Cargo.toml
@@ -25,4 +25,4 @@ codec = { package = "parity-scale-codec", version = "3.6", default-features = fa
 ] }
 
 # rpc
-jsonrpsee = { version = "0.23", features = ["client", "server", "macros"] }
+jsonrpsee = { version = "0.24", features = ["client", "server", "macros"] }

--- a/vendor/composable/cosmwasm/rpc/Cargo.toml
+++ b/vendor/composable/cosmwasm/rpc/Cargo.toml
@@ -11,10 +11,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # substrate primitives
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
 
 # local
 cosmwasm-runtime-api = { workspace = true }

--- a/vendor/composable/cosmwasm/runtime-api/Cargo.toml
+++ b/vendor/composable/cosmwasm/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = [
     "derive",
 ] }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 [features]
 default = ["std"]

--- a/vendor/moonbeam/precompiles/assets-erc20/Cargo.toml
+++ b/vendor/moonbeam/precompiles/assets-erc20/Cargo.toml
@@ -11,21 +11,21 @@ num_enum = { version = "0.7", default-features = false }
 paste = "1.0"
 
 # Substrate
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["max-encoded-len"] }
 scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false }
-pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, features = ["forbid-evm-reentrancy"] }
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false }
+fp-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false }
+pallet-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, features = ["forbid-evm-reentrancy"] }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false }
 
 # Moonkit
 #moonkit-xcm-primitives = { workspace = true }
@@ -37,7 +37,7 @@ serde = "1.0"
 sha3 = "0.10"
 
 # Moonbeam
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", features = ["testing"] }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", features = ["testing"] }
 
 [features]
 default = ["std"]

--- a/vendor/moonbeam/precompiles/assets-erc20/src/eip2612.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/eip2612.rs
@@ -25,6 +25,7 @@ use pallet_assets::pallet::{
 	Instance1, Instance10, Instance11, Instance12, Instance13, Instance14, Instance15, Instance16,
 	Instance2, Instance3, Instance4, Instance5, Instance6, Instance7, Instance8, Instance9,
 };
+use pallet_evm::FrameSystemAccountProvider;
 use scale_info::prelude::string::ToString;
 use sp_core::H256;
 use sp_io::hashing::keccak_256;
@@ -114,15 +115,17 @@ pub struct Eip2612<Runtime, Instance: 'static = ()>(PhantomData<(Runtime, Instan
 impl<Runtime, Instance> Eip2612<Runtime, Instance>
 where
 	Instance: InstanceToPrefix + 'static,
-	Runtime: pallet_assets::Config<Instance> + pallet_evm::Config + frame_system::Config,
+	Runtime: pallet_assets::Config<Instance>
+		+ pallet_evm::Config<AccountProvider = FrameSystemAccountProvider<Runtime>>
+		+ frame_system::Config,
 	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	Runtime::RuntimeCall: From<pallet_assets::Call<Runtime, Instance>>,
-	<Runtime::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<Runtime::AccountId>>,
+	<Runtime::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<AccountIdOf<Runtime>>>,
 	BalanceOf<Runtime, Instance>: TryFrom<U256> + Into<U256> + solidity::Codec,
 	Runtime: AddressToAssetId<AssetIdOf<Runtime, Instance>>,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin: OriginTrait,
 	AssetIdOf<Runtime, Instance>: Display,
-	Runtime::AccountId: Into<H160>,
+	AccountIdOf<Runtime>: Into<H160>,
 {
 	fn compute_domain_separator(address: H160, asset_id: AssetIdOf<Runtime, Instance>) -> [u8; 32] {
 		let asset_name = pallet_assets::Pallet::<Runtime, Instance>::name(asset_id.clone());

--- a/vendor/moonbeam/precompiles/balances-erc20/Cargo.toml
+++ b/vendor/moonbeam/precompiles/balances-erc20/Cargo.toml
@@ -12,19 +12,19 @@ paste = "1.0"
 slices = "0.2"
 
 # Substrate
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 parity-scale-codec = { version = "3.6", default-features = false, features = ["max-encoded-len"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false }
-pallet-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false, features = ["forbid-evm-reentrancy"] }
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", default-features = false }
+fp-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false }
+pallet-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false, features = ["forbid-evm-reentrancy"] }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -33,7 +33,7 @@ serde = "1.0"
 sha3 = "0.10"
 
 # Moonbeam
-precompile-utils = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2407", features = ["testing"] }
+precompile-utils = { git = "https://github.com/polkadot-evm/frontier", rev = "aacf5a4e", features = ["testing"] }
 
 scale-info = { version = "2.11", features = ["derive"] }
 


### PR DESCRIPTION
This PR updates Polkadot SDK dependency to `stable2409` (polkadot-v1.16).