### PR TITLE
test: Add missing AccountProvider to mock runtime

### DIFF
--- a/vendor/moonbeam/precompiles/assets-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/mock.rs
@@ -25,7 +25,7 @@ use frame_support::{
 };
 
 use frame_system::{EnsureNever, EnsureRoot};
-use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
+use pallet_evm::{EnsureAddressNever, EnsureAddressRoot, FrameSystemAccountProvider};
 use precompile_utils::{
 	mock_account,
 	precompile_set::*,
@@ -164,6 +164,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
+	type AccountProvider = FrameSystemAccountProvider<Self>;
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
@@ -19,7 +19,7 @@
 use super::*;
 
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
-use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
+use pallet_evm::{EnsureAddressNever, EnsureAddressRoot, FrameSystemAccountProvider};
 use precompile_utils::{precompile_set::*, testing::MockAccount};
 use sp_core::{ConstU32, H256, U256};
 use sp_runtime::{
@@ -117,6 +117,7 @@ parameter_types! {
 }
 
 impl pallet_evm::Config for Runtime {
+	type AccountProvider = FrameSystemAccountProvider<Self>;
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;


### PR DESCRIPTION
This PR fixes test failure due to missing AccountProvider in mock runtime.