### PR TITLE
ci: Do not run workflows when sidecar is changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'sidecar/**'
   pull_request:
+    paths-ignore:
+      - 'sidecar/**'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR changes CI not to run workflows when the code of sidecar is changed. (Need to add separated CI process for sidecar later)