### PR TITLE
chore: Add dummy version of pallet-solana

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 	"frame/cosmos/x/wasm",
 	"frame/cosmos/x/wasm/types",
 	"frame/multimap",
+	"frame/solana",
 	"primitives/babel",
 	"primitives/cosmos",
 	"primitives/ethereum",
@@ -70,6 +71,7 @@ pallet-cosmwasm = { path = "vendor/composable/cosmwasm", default-features = fals
 pallet-evm-precompileset-assets-erc20 = { path = "vendor/moonbeam/precompiles/assets-erc20", default-features = false }
 pallet-evm-precompile-balances-erc20 = { path = "vendor/moonbeam/precompiles/balances-erc20", default-features = false }
 pallet-multimap = { path = "frame/multimap", default-features = false }
+pallet-solana = { path = "frame/solana", default-features = false }
 
 [profile.release]
 panic = "unwind"

--- a/frame/solana/Cargo.toml
+++ b/frame/solana/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pallet-solana"
+version = "0.4.0"
+authors = ["Haderech Pte. Ltd."]
+edition = "2021"
+license = "GPL-3.0-or-later"
+repository = "https://github.com/noirhq/noir.git"
+publish = false

--- a/frame/solana/src/lib.rs
+++ b/frame/solana/src/lib.rs
@@ -1,0 +1,17 @@
+// This file is part of Noir.
+
+// Copyright (c) Haderech Pte. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/primitives/runtime/src/multi/signature.rs
+++ b/primitives/runtime/src/multi/signature.rs
@@ -106,7 +106,7 @@ impl Verify for MultiSignature {
 			Self::Ecdsa(sig) => {
 				let m = sp_io::hashing::blake2_256(msg.get());
 				sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m)
-					.map_or(false, |pubkey| sp_io::hashing::blake2_256(&pubkey) == who)
+					.is_ok_and(|pubkey| sp_io::hashing::blake2_256(&pubkey) == who)
 			},
 		}
 	}
@@ -133,7 +133,7 @@ impl VerifyMut for MultiSignature {
 			Self::Ecdsa(sig) => {
 				let m = sp_io::hashing::blake2_256(msg.get());
 				sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m)
-					.map_or(false, |pubkey| signer.check(ecdsa::Public::from(pubkey)))
+					.is_ok_and(|pubkey| signer.check(ecdsa::Public::from(pubkey)))
 			},
 		}
 	}


### PR DESCRIPTION
This PR adds a dummy version of `pallet-solana` under the path of `frame/solana`.