### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/frame/cosmos/x/auth/signing/src/sign_mode_handler/mod.rs
+++ b/frame/cosmos/x/auth/signing/src/sign_mode_handler/mod.rs
@@ -146,7 +146,7 @@ mod tests {
 	fn get_sign_bytes_test() {
 		let tx_raw = "CpMBCpABChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEnAKLWNvc21vczFxZDY5bnV3ajk1Z3RhNGFramd5eHRqOXVqbXo0dzhlZG1xeXNxdxItY29zbW9zMWdtajJleGFnMDN0dGdhZnBya2RjM3Q4ODBncm1hOW53ZWZjZDJ3GhAKBXVhdG9tEgcxMDAwMDAwEnEKTgpGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQIKEJE0H+VmS/oXgtXgR3lokGjJFrBMs2XsMVN1VoTZoRIECgIIARIfChUKBXVhdG9tEgw4ODY4ODAwMDAwMDAQgMDxxZSVFBpA9+DRmMYoIcxYF8jpNfUjMIMB4pgZ9diC8ySbnhc6YU84AA3b/0RsCr+nx9AZ27FwcrKJM/yBh8lz+/A9BFn3bg==";
 
-		let tx_raw = Base64::decode_vec(&tx_raw).unwrap();
+		let tx_raw = Base64::decode_vec(tx_raw).unwrap();
 		let tx = Tx::decode(&mut &*tx_raw).unwrap();
 
 		let public_key = tx
@@ -172,7 +172,7 @@ mod tests {
 
 		let sign_doc_raw =
 		"CpMBCpABChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEnAKLWNvc21vczFxZDY5bnV3ajk1Z3RhNGFramd5eHRqOXVqbXo0dzhlZG1xeXNxdxItY29zbW9zMWdtajJleGFnMDN0dGdhZnBya2RjM3Q4ODBncm1hOW53ZWZjZDJ3GhAKBXVhdG9tEgcxMDAwMDAwEnEKTgpGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQIKEJE0H+VmS/oXgtXgR3lokGjJFrBMs2XsMVN1VoTZoRIECgIIARIfChUKBXVhdG9tEgw4ODY4ODAwMDAwMDAQgMDxxZSVFBoRdGhldGEtdGVzdG5ldC0wMDEgrYou";
-		let hash = sha2_256(&Base64::decode_vec(&sign_doc_raw).unwrap());
+		let hash = sha2_256(&Base64::decode_vec(sign_doc_raw).unwrap());
 
 		assert_eq!(expected_hash, hash);
 	}
@@ -203,7 +203,7 @@ mod tests {
 			pub_key: public_key.clone(),
 		};
 		let hash = sha2_256(&SignModeHandler::get_sign_bytes(&mode, &data, &tx).unwrap());
-		let hash = hex::encode(&hash);
+		let hash = hex::encode(hash);
 
 		assert_eq!(hash, "714d4bdfdbd0bd630ebdf93b1f6eba7d3c752e92bbab6c9d3d9c93e1777348bb");
 	}

--- a/frame/cosmos/x/auth/src/sigverify.rs
+++ b/frame/cosmos/x/auth/src/sigverify.rs
@@ -153,9 +153,8 @@ pub fn ecdsa_verify_prehashed(
 			let sig = ecdsa::Signature::from(signature_inner);
 			sp_io::crypto::ecdsa_verify_prehashed(&sig, message_hash, &pub_key)
 		}),
-		65 => ecdsa::Signature::try_from(signature).map_or(false, |sig| {
-			sp_io::crypto::ecdsa_verify_prehashed(&sig, message_hash, &pub_key)
-		}),
+		65 => ecdsa::Signature::try_from(signature)
+			.is_ok_and(|sig| sp_io::crypto::ecdsa_verify_prehashed(&sig, message_hash, &pub_key)),
 		_ => false,
 	}
 }

--- a/vendor/composable/cosmwasm/src/runtimes/vm.rs
+++ b/vendor/composable/cosmwasm/src/runtimes/vm.rs
@@ -214,19 +214,19 @@ pub struct CosmwasmVM<'a, T: Config> {
 	pub contract_runtime: ContractBackend,
 }
 
-impl<'a, T: Config> Has<Env> for CosmwasmVM<'a, T> {
+impl<T: Config> Has<Env> for CosmwasmVM<'_, T> {
 	fn get(&self) -> Env {
 		self.cosmwasm_env.clone()
 	}
 }
 
-impl<'a, T: Config> Has<MessageInfo> for CosmwasmVM<'a, T> {
+impl<T: Config> Has<MessageInfo> for CosmwasmVM<'_, T> {
 	fn get(&self) -> MessageInfo {
 		self.cosmwasm_message_info.clone()
 	}
 }
 
-impl<'a, T: Config> WasmiContext for CosmwasmVM<'a, T> {
+impl<T: Config> WasmiContext for CosmwasmVM<'_, T> {
 	fn executing_module(&self) -> Option<WasmiModule> {
 		self.contract_runtime.executing_module()
 	}
@@ -243,7 +243,7 @@ impl<'a, T: Config> WasmiContext for CosmwasmVM<'a, T> {
 	}
 }
 
-impl<'a, T: Config> CosmwasmVM<'a, T> {
+impl<T: Config> CosmwasmVM<'_, T> {
 	pub fn charge_raw(&mut self, gas: u64) -> Result<(), <Self as VMBase>::Error> {
 		match self.shared.gas.charge(gas) {
 			GasOutcome::Halt => Err(CosmwasmVMError::OutOfGas),
@@ -252,7 +252,7 @@ impl<'a, T: Config> CosmwasmVM<'a, T> {
 	}
 }
 
-impl<'a, T: Config + Send + Sync> VMBase for CosmwasmVM<'a, T> {
+impl<T: Config + Send + Sync> VMBase for CosmwasmVM<'_, T> {
 	type Input<'x> = WasmiInput<OwnedWasmiVM<Self>>;
 	type Output<'x> = WasmiOutput<OwnedWasmiVM<Self>>;
 	type QueryCustom = Empty;
@@ -656,7 +656,7 @@ impl<'a, T: Config + Send + Sync> VMBase for CosmwasmVM<'a, T> {
 	}
 }
 
-impl<'a, T: Config> Transactional for CosmwasmVM<'a, T> {
+impl<T: Config> Transactional for CosmwasmVM<'_, T> {
 	type Error = CosmwasmVMError<T>;
 	fn transaction_begin(&mut self) -> Result<(), Self::Error> {
 		sp_io::storage::start_transaction();

--- a/vendor/composable/vm-wasmi/src/semantic.rs
+++ b/vendor/composable/vm-wasmi/src/semantic.rs
@@ -211,7 +211,7 @@ struct SimpleWasmiVM<'a> {
 	call_depth: u32,
 }
 
-impl<'a> WasmiContext for SimpleWasmiVM<'a> {
+impl WasmiContext for SimpleWasmiVM<'_> {
 	fn executing_module(&self) -> Option<WasmiModule> {
 		self.executing_module.clone()
 	}
@@ -225,7 +225,7 @@ impl<'a> WasmiContext for SimpleWasmiVM<'a> {
 	}
 }
 
-impl<'a> SimpleWasmiVM<'a> {
+impl SimpleWasmiVM<'_> {
 	fn load_subvm(
 		&mut self,
 		address: <Self as VMBase>::Address,
@@ -283,7 +283,7 @@ impl From<CanonicalAddress> for CanonicalAddr {
 	}
 }
 
-impl<'a> VMBase for SimpleWasmiVM<'a> {
+impl VMBase for SimpleWasmiVM<'_> {
 	type Input<'x> = WasmiInput<OwnedWasmiVM<Self>>;
 	type Output<'x> = WasmiOutput<OwnedWasmiVM<Self>>;
 	type QueryCustom = Empty;
@@ -683,12 +683,7 @@ impl<'a> VMBase for SimpleWasmiVM<'a> {
 		value: Self::StorageValue,
 	) -> Result<(), Self::Error> {
 		let contract_addr = self.env.contract.address.clone().try_into()?;
-		self.extension
-			.storage
-			.entry(contract_addr)
-			.or_insert_with(SimpleWasmiVMStorage::default)
-			.data
-			.insert(key, value);
+		self.extension.storage.entry(contract_addr).or_default().data.insert(key, value);
 		Ok(())
 	}
 
@@ -795,18 +790,18 @@ impl From<BankAccount> for Addr {
 	}
 }
 
-impl<'a> Has<Env> for SimpleWasmiVM<'a> {
+impl Has<Env> for SimpleWasmiVM<'_> {
 	fn get(&self) -> Env {
 		self.env.clone()
 	}
 }
-impl<'a> Has<MessageInfo> for SimpleWasmiVM<'a> {
+impl Has<MessageInfo> for SimpleWasmiVM<'_> {
 	fn get(&self) -> MessageInfo {
 		self.info.clone()
 	}
 }
 
-impl<'a> Transactional for SimpleWasmiVM<'a> {
+impl Transactional for SimpleWasmiVM<'_> {
 	type Error = SimpleVMError;
 	fn transaction_begin(&mut self) -> Result<(), Self::Error> {
 		self.extension.transaction_depth += 1;

--- a/vendor/composable/vm-wasmi/src/validation.rs
+++ b/vendor/composable/vm-wasmi/src/validation.rs
@@ -153,7 +153,7 @@ impl<'a> CodeValidation<'a> {
 	/// Currently only a single memory section is supported.
 	pub fn validate_memory_limit(self) -> Result<Self, ValidationError> {
 		let CodeValidation(module) = self;
-		if module.memory_section().map_or(false, |ms| ms.entries().len() != 1) {
+		if module.memory_section().is_some_and(|ms| ms.entries().len() != 1) {
 			Err(ValidationError::MustDeclareOneInternalMemory)
 		} else {
 			Ok(self)

--- a/vendor/composable/vm/src/executor.rs
+++ b/vendor/composable/vm/src/executor.rs
@@ -650,7 +650,7 @@ pub struct CosmwasmCallInput<'a, Pointer, I>(
 	pub Tagged<Pointer, &'a [u8]>,
 	pub PhantomData<I>,
 );
-impl<'a, Pointer, I: Input> Input for CosmwasmCallInput<'a, Pointer, I> {
+impl<Pointer, I: Input> Input for CosmwasmCallInput<'_, Pointer, I> {
 	type Output = Pointer;
 }
 
@@ -660,7 +660,7 @@ pub struct CosmwasmCallWithoutInfoInput<'a, Pointer, I>(
 	pub Tagged<Pointer, &'a [u8]>,
 	pub PhantomData<I>,
 );
-impl<'a, Pointer, I: Input> Input for CosmwasmCallWithoutInfoInput<'a, Pointer, I> {
+impl<Pointer, I: Input> Input for CosmwasmCallWithoutInfoInput<'_, Pointer, I> {
 	type Output = Pointer;
 }
 

--- a/vendor/cosmwasm/std/src/binary.rs
+++ b/vendor/cosmwasm/std/src/binary.rs
@@ -231,7 +231,7 @@ impl<'de> Deserialize<'de> for Binary {
 
 struct Base64Visitor;
 
-impl<'de> de::Visitor<'de> for Base64Visitor {
+impl de::Visitor<'_> for Base64Visitor {
 	type Value = Binary;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/checksum.rs
+++ b/vendor/cosmwasm/std/src/checksum.rs
@@ -94,7 +94,7 @@ impl<'de> Deserialize<'de> for Checksum {
 
 struct ChecksumVisitor;
 
-impl<'de> de::Visitor<'de> for ChecksumVisitor {
+impl de::Visitor<'_> for ChecksumVisitor {
 	type Value = Checksum;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/coins.rs
+++ b/vendor/cosmwasm/std/src/coins.rs
@@ -288,13 +288,13 @@ impl<'a> Iterator for CoinsIter<'a> {
 	}
 }
 
-impl<'a> DoubleEndedIterator for CoinsIter<'a> {
+impl DoubleEndedIterator for CoinsIter<'_> {
 	fn next_back(&mut self) -> Option<Self::Item> {
 		self.0.next_back().map(|(_, coin)| coin)
 	}
 }
 
-impl<'a> ExactSizeIterator for CoinsIter<'a> {
+impl ExactSizeIterator for CoinsIter<'_> {
 	fn len(&self) -> usize {
 		self.0.len()
 	}

--- a/vendor/cosmwasm/std/src/deps.rs
+++ b/vendor/cosmwasm/std/src/deps.rs
@@ -35,7 +35,7 @@ pub struct Deps<'a, C: CustomQuery = Empty> {
 // See "There is a small difference between the two: the derive strategy will also
 // place a Copy bound on type parameters, which isn’t always desired."
 // https://doc.rust-lang.org/std/marker/trait.Copy.html
-impl<'a, C: CustomQuery> Copy for Deps<'a, C> {}
+impl<C: CustomQuery> Copy for Deps<'_, C> {}
 
 impl<S: Storage, A: Api, Q: Querier, C: CustomQuery> OwnedDeps<S, A, Q, C> {
 	pub fn as_ref(&'_ self) -> Deps<'_, C> {

--- a/vendor/cosmwasm/std/src/hex_binary.rs
+++ b/vendor/cosmwasm/std/src/hex_binary.rs
@@ -234,7 +234,7 @@ impl<'de> Deserialize<'de> for HexBinary {
 
 struct HexVisitor;
 
-impl<'de> de::Visitor<'de> for HexVisitor {
+impl de::Visitor<'_> for HexVisitor {
 	type Value = HexBinary;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/decimal.rs
+++ b/vendor/cosmwasm/std/src/math/decimal.rs
@@ -743,7 +743,7 @@ impl<'de> Deserialize<'de> for Decimal {
 
 struct DecimalVisitor;
 
-impl<'de> de::Visitor<'de> for DecimalVisitor {
+impl de::Visitor<'_> for DecimalVisitor {
 	type Value = Decimal;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/decimal256.rs
+++ b/vendor/cosmwasm/std/src/math/decimal256.rs
@@ -747,7 +747,7 @@ impl<'de> Deserialize<'de> for Decimal256 {
 
 struct Decimal256Visitor;
 
-impl<'de> de::Visitor<'de> for Decimal256Visitor {
+impl de::Visitor<'_> for Decimal256Visitor {
 	type Value = Decimal256;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/int128.rs
+++ b/vendor/cosmwasm/std/src/math/int128.rs
@@ -552,7 +552,7 @@ impl<'de> Deserialize<'de> for Int128 {
 
 struct Int128Visitor;
 
-impl<'de> de::Visitor<'de> for Int128Visitor {
+impl de::Visitor<'_> for Int128Visitor {
 	type Value = Int128;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/int256.rs
+++ b/vendor/cosmwasm/std/src/math/int256.rs
@@ -627,7 +627,7 @@ impl<'de> Deserialize<'de> for Int256 {
 
 struct Int256Visitor;
 
-impl<'de> de::Visitor<'de> for Int256Visitor {
+impl de::Visitor<'_> for Int256Visitor {
 	type Value = Int256;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/int512.rs
+++ b/vendor/cosmwasm/std/src/math/int512.rs
@@ -629,7 +629,7 @@ impl<'de> Deserialize<'de> for Int512 {
 
 struct Int512Visitor;
 
-impl<'de> de::Visitor<'de> for Int512Visitor {
+impl de::Visitor<'_> for Int512Visitor {
 	type Value = Int512;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/int64.rs
+++ b/vendor/cosmwasm/std/src/math/int64.rs
@@ -531,7 +531,7 @@ impl<'de> Deserialize<'de> for Int64 {
 
 struct Int64Visitor;
 
-impl<'de> de::Visitor<'de> for Int64Visitor {
+impl de::Visitor<'_> for Int64Visitor {
 	type Value = Int64;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/signed_decimal.rs
+++ b/vendor/cosmwasm/std/src/math/signed_decimal.rs
@@ -878,7 +878,7 @@ impl<'de> Deserialize<'de> for SignedDecimal {
 
 struct SignedDecimalVisitor;
 
-impl<'de> de::Visitor<'de> for SignedDecimalVisitor {
+impl de::Visitor<'_> for SignedDecimalVisitor {
 	type Value = SignedDecimal;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/signed_decimal_256.rs
+++ b/vendor/cosmwasm/std/src/math/signed_decimal_256.rs
@@ -879,7 +879,7 @@ impl<'de> Deserialize<'de> for SignedDecimal256 {
 
 struct SignedDecimal256Visitor;
 
-impl<'de> de::Visitor<'de> for SignedDecimal256Visitor {
+impl de::Visitor<'_> for SignedDecimal256Visitor {
 	type Value = SignedDecimal256;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/uint128.rs
+++ b/vendor/cosmwasm/std/src/math/uint128.rs
@@ -575,7 +575,7 @@ impl<'de> Deserialize<'de> for Uint128 {
 
 struct Uint128Visitor;
 
-impl<'de> de::Visitor<'de> for Uint128Visitor {
+impl de::Visitor<'_> for Uint128Visitor {
 	type Value = Uint128;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/uint256.rs
+++ b/vendor/cosmwasm/std/src/math/uint256.rs
@@ -655,7 +655,7 @@ impl<'de> Deserialize<'de> for Uint256 {
 
 struct Uint256Visitor;
 
-impl<'de> de::Visitor<'de> for Uint256Visitor {
+impl de::Visitor<'_> for Uint256Visitor {
 	type Value = Uint256;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/uint512.rs
+++ b/vendor/cosmwasm/std/src/math/uint512.rs
@@ -641,7 +641,7 @@ impl<'de> Deserialize<'de> for Uint512 {
 
 struct Uint512Visitor;
 
-impl<'de> de::Visitor<'de> for Uint512Visitor {
+impl de::Visitor<'_> for Uint512Visitor {
 	type Value = Uint512;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/math/uint64.rs
+++ b/vendor/cosmwasm/std/src/math/uint64.rs
@@ -549,7 +549,7 @@ impl<'de> Deserialize<'de> for Uint64 {
 
 struct Uint64Visitor;
 
-impl<'de> de::Visitor<'de> for Uint64Visitor {
+impl de::Visitor<'_> for Uint64Visitor {
 	type Value = Uint64;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/vendor/cosmwasm/std/src/traits.rs
+++ b/vendor/cosmwasm/std/src/traits.rs
@@ -344,7 +344,7 @@ pub struct QuerierWrapper<'a, C: CustomQuery = Empty> {
 // See "There is a small difference between the two: the derive strategy will also
 // place a Copy bound on type parameters, which isn’t always desired."
 // https://doc.rust-lang.org/std/marker/trait.Copy.html
-impl<'a, C: CustomQuery> Copy for QuerierWrapper<'a, C> {}
+impl<C: CustomQuery> Copy for QuerierWrapper<'_, C> {}
 
 /// This allows us to use self.raw_query to access the querier.
 /// It also allows external callers to access the querier easily.

--- a/vendor/moonbeam/precompiles/assets-erc20/src/eip2612.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/eip2612.rs
@@ -150,7 +150,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(
@@ -183,6 +183,7 @@ where
 
 	// Translated from
 	// https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol#L81
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn permit(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -222,8 +223,8 @@ where
 		);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/vendor/moonbeam/precompiles/assets-erc20/src/lib.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/lib.rs
@@ -78,13 +78,13 @@ pub trait AddressToAssetId<AssetId> {
 /// 1024-2047 Precompiles that are not in Ethereum Mainnet but are neither Moonbeam specific
 /// 2048-4095 Moonbeam specific precompiles
 /// Asset precompiles can only fall between
-/// 	0xFFFFFFFF00000000000000000000000000000000 - 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+///     0xFFFFFFFF00000000000000000000000000000000 - 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 /// The precompile for AssetId X, where X is a u128 (i.e.16 bytes), if 0XFFFFFFFF + Bytes(AssetId)
 /// In order to route the address to Erc20AssetsPrecompile<R>, we first check whether the AssetId
 /// exists in pallet-assets
 /// We cannot do this right now, so instead we check whether the total supply is zero. If so, we
 /// do not route to the precompiles
-
+///
 /// This means that every address that starts with 0xFFFFFFFF will go through an additional db read,
 /// but the probability for this to happen is 2^-32 for random addresses
 pub struct Erc20AssetsPrecompileSet<Runtime, Instance: 'static = ()>(
@@ -354,7 +354,7 @@ where
 		{
 			let caller: AccountIdOf<Runtime> =
 				Runtime::AddressMapping::into_account_id(handle.context().caller);
-			let from: AccountIdOf<Runtime> = Runtime::AddressMapping::into_account_id(from.clone());
+			let from: AccountIdOf<Runtime> = Runtime::AddressMapping::into_account_id(from);
 			let to: AccountIdOf<Runtime> = Runtime::AddressMapping::into_account_id(to);
 
 			// If caller is "from", it can spend as much as it wants from its own balance.
@@ -517,6 +517,7 @@ where
 		Ok(Address(freezer))
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	#[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
 	fn eip2612_permit(
 		asset_id: AssetIdOf<Runtime, Instance>,

--- a/vendor/moonbeam/precompiles/assets-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/mock.rs
@@ -59,7 +59,7 @@ impl AddressToAssetId<AssetId> for Runtime {
 	/// The way to convert an account to assetId is by ensuring that the prefix is 0XFFFFFFFF
 	/// and by taking the lowest 128 bits as the assetId
 	fn address_to_asset_id(address: H160) -> Option<AssetId> {
-		if &address[..4] == &FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX.to_be_bytes()[..] {
+		if address[..4] == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX.to_be_bytes()[..] {
 			return Some(AssetId::from_be_bytes(address[4..].try_into().unwrap()));
 		}
 		None
@@ -250,15 +250,10 @@ construct_runtime!(
 	}
 );
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/vendor/moonbeam/precompiles/assets-erc20/src/tests.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/tests.rs
@@ -454,8 +454,8 @@ fn transfer_not_enough_founds() {
 					ForeignPCall::transfer { to: Address(Charlie.into()), value: 50.into() },
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output).unwrap().contains("Dispatched call failed with error: ") &&
-						from_utf8(&output).unwrap().contains("BalanceLow")
+					from_utf8(output).unwrap().contains("Dispatched call failed with error: ") &&
+						from_utf8(output).unwrap().contains("BalanceLow")
 				});
 		});
 }

--- a/vendor/moonbeam/precompiles/balances-erc20/src/eip2612.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/eip2612.rs
@@ -61,7 +61,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(
@@ -93,6 +93,7 @@ where
 
 	// Translated from
 	// https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol#L81
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn permit(
 		handle: &mut impl PrecompileHandle,
 		owner: Address,
@@ -122,8 +123,8 @@ where
 			Self::generate_permit(handle.context().address, owner, spender, value, nonce, deadline);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/vendor/moonbeam/precompiles/balances-erc20/src/lib.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/lib.rs
@@ -458,6 +458,7 @@ where
 		Ok(())
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	#[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
 	fn eip2612_permit(
 		handle: &mut impl PrecompileHandle,

--- a/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
@@ -174,15 +174,10 @@ impl Erc20Metadata for Runtime {
 	}
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/vendor/moonbeam/precompiles/balances-erc20/src/tests.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/tests.rs
@@ -306,8 +306,8 @@ fn transfer_not_enough_funds() {
 					PCall::transfer { to: Address(Bob.into()), value: 1400.into() },
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output).unwrap().contains("Dispatched call failed with error: ") &&
-						from_utf8(&output).unwrap().contains("FundsUnavailable")
+					from_utf8(output).unwrap().contains("Dispatched call failed with error: ") &&
+						from_utf8(output).unwrap().contains("FundsUnavailable")
 				});
 		});
 }
@@ -806,7 +806,7 @@ fn permit_valid() {
 					SELECTOR_LOG_APPROVAL,
 					CryptoAlith,
 					Bob,
-					solidity::encode_event_data(U256::from(value)),
+					solidity::encode_event_data(value),
 				))
 				.execute_returns(());
 


### PR DESCRIPTION
This PR fixes clippy warnings based on the latest nightly Rust toolchain.