### PR TITLE
chore: Bump version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,14 +88,8 @@ pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", bra
 precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
 
 # noir
-composable-support = { path = "vendor/composable/composable-support", default-features = false }
 cosmos-rpc = { path = "frame/cosmos/rpc", default-features = false }
 cosmos-runtime-api = { path = "frame/cosmos/runtime-api", default-features = false }
-cosmwasm-rpc = { path = "vendor/composable/cosmwasm/rpc" }
-cosmwasm-runtime-api = { path = "vendor/composable/cosmwasm/runtime-api", default-features = false }
-cosmwasm-std = { path = "vendor/cosmwasm/std", default-features = false }
-cosmwasm-vm = { path = "vendor/composable/vm", default-features = false }
-cosmwasm-vm-wasmi = { path = "vendor/composable/vm-wasmi", default-features = false }
 frame-babel = { path = "frame/babel", default-features = false }
 noir-core-primitives = { path = "core-primitives", default-features = false }
 noir-runtime-common = { path = "runtime/common", default-features = false }
@@ -114,11 +108,19 @@ pallet-cosmos-x-bank = { path = "frame/cosmos/x/bank", default-features = false 
 pallet-cosmos-x-bank-types = { path = "frame/cosmos/x/bank/types", default-features = false }
 pallet-cosmos-x-wasm = { path = "frame/cosmos/x/wasm", default-features = false }
 pallet-cosmos-x-wasm-types = { path = "frame/cosmos/x/wasm/types", default-features = false }
+pallet-multimap = { path = "frame/multimap", default-features = false }
+pallet-solana = { path = "frame/solana", default-features = false }
+
+# vendor
+composable-support = { path = "vendor/composable/composable-support", default-features = false }
+cosmwasm-rpc = { path = "vendor/composable/cosmwasm/rpc" }
+cosmwasm-runtime-api = { path = "vendor/composable/cosmwasm/runtime-api", default-features = false }
+cosmwasm-std = { path = "vendor/cosmwasm/std", default-features = false }
+cosmwasm-vm = { path = "vendor/composable/vm", default-features = false }
+cosmwasm-vm-wasmi = { path = "vendor/composable/vm-wasmi", default-features = false }
 pallet-cosmwasm = { path = "vendor/composable/cosmwasm", default-features = false }
 pallet-evm-precompileset-assets-erc20 = { path = "vendor/moonbeam/precompiles/assets-erc20", default-features = false }
 pallet-evm-precompile-balances-erc20 = { path = "vendor/moonbeam/precompiles/balances-erc20", default-features = false }
-pallet-multimap = { path = "frame/multimap", default-features = false }
-pallet-solana = { path = "frame/solana", default-features = false }
 
 [profile.release]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ default-members = [
 [workspace.dependencies]
 bech32 = { version = "0.11", default-features = false }
 bs58 = { version = "0.5.1", default-features = false }
-buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
+buidl = { version = "0.2", default-features = false, features = ["derive"] }
 const-hex = { version = "1.13", default-features = false }
 cosmos-sdk-proto = { version = "0.24", default-features = false }
 ethereum = { version = "0.15.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace.package]
+authors = ["Haderech Pte. Ltd."]
+version = "0.5.0"
+edition = "2021"
+repository = "https://github.com/noirhq/noir.git"
+
 [workspace]
 resolver = "2"
 members = [
@@ -41,6 +47,47 @@ default-members = [
 ]
 
 [workspace.dependencies]
+bech32 = { version = "0.11", default-features = false }
+bs58 = { version = "0.5.1", default-features = false }
+buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
+const-hex = { version = "1.13", default-features = false }
+cosmos-sdk-proto = { version = "0.24", default-features = false }
+ethereum = { version = "0.15.0", default-features = false }
+hex-literal = "0.4"
+k256 = { version = "0.13", default-features = false }
+num_enum = { version = "0.7", default-features = false }
+parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
+ripemd = { version = "0.1", default-features = false }
+scale-info = { version = "2.11", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde-json-wasm = { version = "1.0", default-features = false }
+static_assertions = "1.1"
+
+# substrate
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+
+# frontier
+fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+fp-self-contained = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-blake2 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+
+# noir
 composable-support = { path = "vendor/composable/composable-support", default-features = false }
 cosmos-rpc = { path = "frame/cosmos/rpc", default-features = false }
 cosmos-runtime-api = { path = "frame/cosmos/runtime-api", default-features = false }

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "noir-core-primitives"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir core primitive types"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
 np-runtime = { workspace = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/babel/Cargo.toml
+++ b/frame/babel/Cargo.toml
@@ -1,62 +1,63 @@
 [package]
 name = "frame-babel"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "FRAME babel for cross-protocol compatibility"
 license = "GPL-3.0-or-later"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-bech32 = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
-cosmos-sdk-proto = { version = "0.24", default-features = false, optional = true }
+bech32 = { workspace = true, optional = true }
+cosmos-sdk-proto = { workspace = true, optional = true }
 cosmwasm-std = { workspace = true, default-features = false, optional = true }
 cosmwasm-vm = { workspace = true, default-features = false, optional = true }
 cosmwasm-vm-wasmi = { workspace = true, default-features = false, optional = true }
-ethereum = { version = "0.15.0", default-features = false, optional = true }
-fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-hex-literal = "0.4"
+ethereum = { workspace = true, optional = true }
+fp-evm = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+hex-literal = { workspace = true }
 np-babel = { workspace = true, default-features = false }
-num_enum = { version = "0.7", default-features = false, optional = true }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false, optional = true }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+num_enum = { workspace = true, optional = true }
+pallet-assets = { workspace = true, optional = true }
+pallet-balances = { workspace = true }
 pallet-cosmos = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-types = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-x-auth-signing = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-x-bank = { workspace = true, default-features = false, optional = true }
 pallet-cosmos-x-wasm = { workspace = true, default-features = false, optional = true }
 pallet-cosmwasm = { workspace = true, default-features = false, optional = true }
-pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
-pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
+pallet-ethereum = { workspace = true, optional = true }
+pallet-evm = { workspace = true, optional = true }
 pallet-evm-precompileset-assets-erc20 = { workspace = true, optional = true }
 pallet-evm-precompile-balances-erc20 = { workspace = true, optional = true }
-pallet-evm-precompile-blake2 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
-pallet-evm-precompile-bn128 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
-pallet-evm-precompile-modexp = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
-pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
+pallet-evm-precompile-blake2 = { workspace = true, optional = true }
+pallet-evm-precompile-bn128 = { workspace = true, optional = true }
+pallet-evm-precompile-modexp = { workspace = true, optional = true }
+pallet-evm-precompile-simple = { workspace = true, optional = true }
 pallet-multimap = { workspace = true, default-features = false }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, optional = true }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0.210", default-features = false, features = ["derive"], optional = true }
-serde-json-wasm = { version = "1.0.1", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+parity-scale-codec = { workspace = true }
+precompile-utils = { workspace = true, optional = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+serde-json-wasm = { workspace = true, optional = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
-const-hex = "1.13"
+const-hex = { workspace = true, default-features = true }
 # substrate
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+pallet-assets = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-sudo = { workspace = true, default-features = true }
+pallet-timestamp = { workspace = true, default-features = true }
+sp-keyring = { workspace = true, default-features = true }
 # frontier
-pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "stable2409" }
-pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409" }
+pallet-ethereum = { workspace = true, default-features = true }
+pallet-evm = { workspace = true, default-features = true }
 # noir
 np-runtime = { workspace = true, default-features = true }
 pallet-cosmos = { workspace = true, default-features = true }

--- a/frame/cosmos/Cargo.toml
+++ b/frame/cosmos/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
 name = "pallet-cosmos"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "FRAME cosmos to process Cosmos transactions"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+cosmos-sdk-proto = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 pallet-cosmos-x-auth-signing = { workspace = true, default-features = false }
 pallet-cosmos-types = { workspace = true, default-features = false }
 pallet-multimap = { workspace = true, default-features = false }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true }
 np-cosmos = { workspace = true, default-features = false }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+scale-info = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
@@ -35,4 +36,13 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 ]
-try-runtime = []
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/frame/multimap/Cargo.toml
+++ b/frame/multimap/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "pallet-multimap"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "FRAME multimap for multi-value maps"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-parity-scale-codec = { version = "3.6", default-features = false }
-scale-info = { version = "2.11", default-features = false }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-io = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]

--- a/frame/solana/Cargo.toml
+++ b/frame/solana/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "pallet-solana"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "FRAME solana to process Solana transactions"
 license = "GPL-3.0-or-later"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false

--- a/primitives/babel/Cargo.toml
+++ b/primitives/babel/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "np-babel"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir primitive types for cross-protocol compatibility"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
@@ -12,10 +13,10 @@ np-cosmos = { workspace = true, optional = true }
 np-ethereum = { workspace = true, optional = true }
 np-nostr = { workspace = true, optional = true }
 np-solana = { workspace = true, optional = true }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true }
 
 [features]
 default = [

--- a/primitives/cosmos/Cargo.toml
+++ b/primitives/cosmos/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
 name = "np-cosmos"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir primitive types for Cosmos compatibility"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-bech32 = { version = "0.11", default-features = false, optional = true }
-buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-ripemd = { version = "0.1", default-features = false }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+bech32 = { workspace = true, optional = true }
+buidl = { workspace = true }
+parity-scale-codec = { workspace = true }
+ripemd = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
-const-hex = "1.12.0"
+const-hex = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/cosmos/src/lib.rs
+++ b/primitives/cosmos/src/lib.rs
@@ -41,7 +41,7 @@ use sp_runtime::traits::AccountIdConversion;
 
 /// Cosmos address.
 #[derive(FixedBytes)]
-#[buidl(substrate(Core, Codec, TypeInfo))]
+#[buidl(derive(Substrate), skip_derive(PassBy))]
 pub struct Address<T = CosmosHub>([u8; 20], PhantomData<fn() -> T>);
 
 impl<T> From<H160> for Address<T> {

--- a/primitives/ethereum/Cargo.toml
+++ b/primitives/ethereum/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "np-ethereum"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir primitive types for Ethereum compatibility"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
-const-hex = { version = "1.12", default-features = false, optional = true }
-k256 = { version = "0.13", default-features = false }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+buidl = { workspace = true }
+const-hex = { workspace = true, optional = true }
+k256 = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/ethereum/src/lib.rs
+++ b/primitives/ethereum/src/lib.rs
@@ -34,7 +34,7 @@ use sp_runtime::traits::AccountIdConversion;
 
 /// Ethereum address.
 #[derive(FixedBytes)]
-#[buidl(substrate(Core, Codec, TypeInfo))]
+#[buidl(derive(Substrate), skip_derive(PassBy))]
 pub struct Address([u8; 20]);
 
 impl From<H160> for Address {

--- a/primitives/nostr/Cargo.toml
+++ b/primitives/nostr/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
 name = "np-nostr"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir primitive types for Nostr compatibility"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-bech32 = { version = "0.11", default-features = false, optional = true }
-buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+bech32 = { workspace = true, optional = true }
+buidl = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
-const-hex = { version = "1.12", default-features = false }
+const-hex = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]

--- a/primitives/nostr/src/lib.rs
+++ b/primitives/nostr/src/lib.rs
@@ -37,7 +37,7 @@ const NPUB: Hrp = Hrp::parse_unchecked("npub");
 
 /// Nostr address.
 #[derive(FixedBytes)]
-#[buidl(substrate(Core, Codec, TypeInfo))]
+#[buidl(derive(Substrate), skip_derive(PassBy))]
 pub struct Address([u8; 32]);
 
 impl From<H256> for Address {

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
 name = "np-runtime"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir primitive types for runtime"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
-const-hex = { version = "1.12", default-features = false }
-fp-self-contained = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+buidl = { workspace = true }
+const-hex = { workspace = true }
+fp-self-contained = { workspace = true }
+frame-support = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/runtime/src/accountid32.rs
+++ b/primitives/runtime/src/accountid32.rs
@@ -240,7 +240,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	type AccountId32 = super::AccountId32<crate::MultiSigner>;
+	use super::*;
 
 	#[test]
 	fn accountid_32_from_str_works() {

--- a/primitives/runtime/src/accountid32.rs
+++ b/primitives/runtime/src/accountid32.rs
@@ -30,16 +30,22 @@ use sp_io::hashing::blake2_256;
 
 /// An opaque 32-byte cryptographic identifier.
 #[derive(FixedBytes)]
-#[buidl(substrate(Codec, Core))]
-pub struct AccountId32<T: Clone = MultiSigner>([u8; 32], Option<T>);
+#[buidl(derive(Substrate), skip_derive(Clone, PassBy, TypeInfo))]
+pub struct AccountId32<T = MultiSigner>([u8; 32], Option<T>);
 
-impl<T: Clone> AccountId32<T> {
+impl<T> AccountId32<T> {
 	pub const fn new(inner: [u8; 32]) -> Self {
 		Self(inner, None)
 	}
 }
 
-impl<T: Clone> TypeInfo for AccountId32<T> {
+impl<T: Clone> Clone for AccountId32<T> {
+	fn clone(&self) -> Self {
+		Self(self.0, self.1.clone())
+	}
+}
+
+impl<T> TypeInfo for AccountId32<T> {
 	type Identity = crypto::AccountId32;
 
 	fn type_info() -> Type {
@@ -48,46 +54,46 @@ impl<T: Clone> TypeInfo for AccountId32<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<T: Clone> Ss58Codec for AccountId32<T> {}
+impl<T> Ss58Codec for AccountId32<T> {}
 
-impl<T: Clone> From<H256> for AccountId32<T> {
+impl<T> From<H256> for AccountId32<T> {
 	fn from(h: H256) -> Self {
 		Self(h.0, None)
 	}
 }
 
-impl<T: Clone> From<AccountId32<T>> for H256 {
+impl<T> From<AccountId32<T>> for H256 {
 	fn from(acc: AccountId32<T>) -> Self {
 		Self(acc.0)
 	}
 }
 
-impl<T: Clone> From<AccountId32<T>> for H160 {
+impl<T> From<AccountId32<T>> for H160 {
 	fn from(acc: AccountId32<T>) -> Self {
 		H256::from(acc).into()
 	}
 }
 
-impl<T: Clone> From<crypto::AccountId32> for AccountId32<T> {
+impl<T> From<crypto::AccountId32> for AccountId32<T> {
 	fn from(acc: crypto::AccountId32) -> Self {
 		Self(Into::<[u8; 32]>::into(acc), None)
 	}
 }
 
-impl<T: Clone> From<AccountId32<T>> for crypto::AccountId32 {
+impl<T> From<AccountId32<T>> for crypto::AccountId32 {
 	fn from(acc: AccountId32<T>) -> Self {
 		Self::from(acc.0)
 	}
 }
 
 #[cfg(feature = "std")]
-impl<T: Clone> std::fmt::Display for AccountId32<T> {
+impl<T> std::fmt::Display for AccountId32<T> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "{}", self.to_ss58check())
 	}
 }
 
-impl<T: Clone> core::fmt::Debug for AccountId32<T> {
+impl<T> core::fmt::Debug for AccountId32<T> {
 	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
 		#[cfg(feature = "serde")]
 		{
@@ -103,7 +109,7 @@ impl<T: Clone> core::fmt::Debug for AccountId32<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<T: Clone> serde::Serialize for AccountId32<T> {
+impl<T> serde::Serialize for AccountId32<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -113,7 +119,7 @@ impl<T: Clone> serde::Serialize for AccountId32<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T: Clone> serde::Deserialize<'de> for AccountId32<T> {
+impl<'de, T> serde::Deserialize<'de> for AccountId32<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -124,7 +130,7 @@ impl<'de, T: Clone> serde::Deserialize<'de> for AccountId32<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T: Clone> std::str::FromStr for AccountId32<T> {
+impl<T> std::str::FromStr for AccountId32<T> {
 	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -139,7 +145,7 @@ impl<T: Clone> std::str::FromStr for AccountId32<T> {
 	}
 }
 
-impl<T: Clone> From<ed25519::Public> for AccountId32<T>
+impl<T> From<ed25519::Public> for AccountId32<T>
 where
 	T: From<ed25519::Public>,
 {
@@ -148,7 +154,7 @@ where
 	}
 }
 
-impl<T: Clone> From<sr25519::Public> for AccountId32<T>
+impl<T> From<sr25519::Public> for AccountId32<T>
 where
 	T: From<sr25519::Public>,
 {
@@ -157,7 +163,7 @@ where
 	}
 }
 
-impl<T: Clone> From<ecdsa::Public> for AccountId32<T>
+impl<T> From<ecdsa::Public> for AccountId32<T>
 where
 	T: From<ecdsa::Public>,
 {
@@ -166,7 +172,7 @@ where
 	}
 }
 
-impl<T: Clone, E> TryFrom<AccountId32<T>> for ecdsa::Public
+impl<T, E> TryFrom<AccountId32<T>> for ecdsa::Public
 where
 	T: TryInto<ecdsa::Public, Error = E>,
 	E: Default,
@@ -181,7 +187,7 @@ where
 	}
 }
 
-impl<T: Clone> Property for AccountId32<T> {
+impl<T> Property for AccountId32<T> {
 	type Value = Option<T>;
 
 	fn get(&self) -> &Option<T> {
@@ -193,7 +199,7 @@ impl<T: Clone> Property for AccountId32<T> {
 	}
 }
 
-impl<T: Clone> Checkable<ed25519::Public> for AccountId32<T>
+impl<T> Checkable<ed25519::Public> for AccountId32<T>
 where
 	T: From<ed25519::Public>,
 {
@@ -208,7 +214,7 @@ where
 	}
 }
 
-impl<T: Clone> Checkable<sr25519::Public> for AccountId32<T>
+impl<T> Checkable<sr25519::Public> for AccountId32<T>
 where
 	T: From<sr25519::Public>,
 {
@@ -223,7 +229,7 @@ where
 	}
 }
 
-impl<T: Clone> Checkable<ecdsa::Public> for AccountId32<T>
+impl<T> Checkable<ecdsa::Public> for AccountId32<T>
 where
 	T: From<ecdsa::Public>,
 {
@@ -241,6 +247,8 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	type AccountId32 = super::AccountId32<MultiSigner>;
 
 	#[test]
 	fn accountid_32_from_str_works() {

--- a/primitives/solana/Cargo.toml
+++ b/primitives/solana/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "np-solana"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir primitive types for Solana compatibility"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-bs58 = { version = "0.5.1", default-features = false, optional = true }
-buidl = { version = "0.1.1", default-features = false, features = ["derive"] }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, optional = true }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+bs58 = { workspace = true, optional = true }
+buidl = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/solana/src/lib.rs
+++ b/primitives/solana/src/lib.rs
@@ -30,7 +30,7 @@ use sp_core::{ed25519, H256};
 
 /// Solana address.
 #[derive(FixedBytes)]
-#[buidl(substrate(Core, Codec, TypeInfo))]
+#[buidl(derive(Substrate), skip_derive(PassBy))]
 pub struct Address([u8; 32]);
 
 impl From<H256> for Address {

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "noir-runtime-common"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
+description = "Noir runtime common types"
 license = "GPL-3.0-or-later"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 noir-core-primitives = { workspace = true }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-static_assertions = "1.1"
+pallet-transaction-payment = { workspace = true }
+static_assertions = { workspace = true }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR bumps the version of Noir to `0.5.0`.