### PR TITLE
fix: Fix build errors on wasm32 target with no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ derive-where = "1.2"
 eager = "0.1.0"
 enum-iterator = "1.5.0"
 ethereum = { version = "0.15.0", default-features = false }
+getrandom = { version = "0.2", default-features = false }
 hex-literal = "0.4"
 itertools = { version = "0.12.1", default-features = false }
 k256 = { version = "0.13", default-features = false }

--- a/frame/solana/Cargo.toml
+++ b/frame/solana/Cargo.toml
@@ -39,6 +39,9 @@ solana-sdk = { workspace = true, features = ["full", "scale"] }
 solana-system-program = { workspace = true }
 solana_rbpf = { workspace = true }
 
+# workaround
+getrandom = { workspace = true, features = ["custom"] }
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 libsecp256k1 = { workspace = true, default-features = true }
@@ -62,6 +65,7 @@ std = [
 	"parity-scale-codec/std",
 	"scale-info/std",
 	"serde/std",
+	"solana-address-lookup-table-program/std",
 	"solana-bpf-loader-program/std",
 	"solana-compute-budget/std",
 	"solana-compute-budget-program/std",

--- a/frame/solana/src/runtime/bank.rs
+++ b/frame/solana/src/runtime/bank.rs
@@ -43,7 +43,7 @@ use frame_support::{
 	BoundedVec,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
-use nostd::{marker::PhantomData, sync::Arc};
+use nostd::{marker::PhantomData, prelude::*, sync::Arc};
 use np_runtime::traits::LateInit;
 use solana_program_runtime::loaded_programs::ProgramCacheEntry;
 use solana_sdk::{

--- a/frame/solana/src/svm/account_rent_state.rs
+++ b/frame/solana/src/svm/account_rent_state.rs
@@ -106,6 +106,7 @@ impl RentState {
 	}
 
 	fn submit_rent_state_metrics(pre_rent_state: &Self, post_rent_state: &Self) {
+		#[cfg(feature = "std")]
 		match (pre_rent_state, post_rent_state) {
 			(&RentState::Uninitialized, &RentState::RentPaying { .. }) => {
 				inc_new_counter_info!("rent_paying_err-new_account", 1);

--- a/frame/solana/src/svm/message_processor.rs
+++ b/frame/solana/src/svm/message_processor.rs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use nostd::prelude::*;
 use solana_measure::measure::Measure;
 use solana_program_runtime::{
 	invoke_context::InvokeContext,

--- a/frame/solana/src/svm/program_loader.rs
+++ b/frame/solana/src/svm/program_loader.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use crate::svm::transaction_processing_callback::TransactionProcessingCallback;
-use nostd::sync::Arc;
+use nostd::{prelude::*, sync::Arc};
 use solana_program_runtime::{
 	loaded_programs::{
 		LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
@@ -53,7 +53,7 @@ pub(crate) fn load_program_from_bytes(
 	deployment_slot: Slot,
 	program_runtime_environment: ProgramRuntimeEnvironment,
 	reloading: bool,
-) -> std::result::Result<ProgramCacheEntry, Box<dyn std::error::Error>> {
+) -> core::result::Result<ProgramCacheEntry, Box<dyn core::error::Error>> {
 	if reloading {
 		// Safety: this is safe because the program is being reloaded in the cache.
 		unsafe {

--- a/frame/solana/src/svm/transaction_account_state_info.rs
+++ b/frame/solana/src/svm/transaction_account_state_info.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use crate::svm::account_rent_state::RentState;
+use nostd::prelude::*;
 use solana_sdk::{
 	account::ReadableAccount,
 	message::SanitizedMessage,

--- a/frame/solana/src/svm/transaction_results.rs
+++ b/frame/solana/src/svm/transaction_results.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 // Re-exported since these have moved to `solana_sdk`.
-use nostd::{collections::BTreeMap, sync::Arc};
+use nostd::{collections::BTreeMap, prelude::*, sync::Arc};
 use serde::{Deserialize, Serialize};
 use solana_program_runtime::loaded_programs::ProgramCacheEntry;
 #[deprecated(

--- a/vendor/solana/curves/curve25519/src/edwards.rs
+++ b/vendor/solana/curves/curve25519/src/edwards.rs
@@ -1,5 +1,8 @@
-use bytemuck_derive::{Pod, Zeroable};
 pub use target_arch::*;
+use {
+    alloc::vec::Vec,
+    bytemuck_derive::{Pod, Zeroable},
+};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
 #[repr(transparent)]

--- a/vendor/solana/curves/curve25519/src/lib.rs
+++ b/vendor/solana/curves/curve25519/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::arithmetic_side_effects, clippy::op_ref)]
 //! Syscall operations for curve25519
 
+extern crate alloc;
+
 pub mod curve_syscall_traits;
 pub mod edwards;
 pub mod errors;

--- a/vendor/solana/curves/curve25519/src/ristretto.rs
+++ b/vendor/solana/curves/curve25519/src/ristretto.rs
@@ -1,5 +1,8 @@
-use bytemuck_derive::{Pod, Zeroable};
 pub use target_arch::*;
+use {
+    alloc::vec::Vec,
+    bytemuck_derive::{Pod, Zeroable},
+};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
 #[repr(transparent)]

--- a/vendor/solana/program-runtime/Cargo.toml
+++ b/vendor/solana/program-runtime/Cargo.toml
@@ -26,7 +26,7 @@ solana-compute-budget = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-measure = { workspace = true }
-solana-metrics = { workspace = true }
+solana-metrics = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
 #solana-type-overrides = { workspace = true }
 #solana-vote = { workspace = true }
@@ -62,6 +62,7 @@ std = [
     "serde/std",
     "solana-compute-budget/std",
     "solana-measure/std",
+    "solana-metrics",
     "solana-sdk/std",
     "solana_rbpf/std",
     "thiserror/std",

--- a/vendor/solana/program-runtime/src/invoke_context.rs
+++ b/vendor/solana/program-runtime/src/invoke_context.rs
@@ -14,6 +14,7 @@ use {
     nostd::{
         alloc::Layout,
         cell::RefCell,
+        prelude::*,
         rc::Rc,
         sync::{atomic::Ordering, Arc},
     },
@@ -571,7 +572,7 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Consume compute units
-    pub fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn core::error::Error>> {
         let mut compute_meter = self.compute_meter.borrow_mut();
         let exceeded = *compute_meter < amount;
         *compute_meter = compute_meter.saturating_sub(amount);
@@ -650,7 +651,7 @@ impl<'a> InvokeContext<'a> {
     pub fn get_syscall_context(&self) -> Result<&SyscallContext, InstructionError> {
         self.syscall_context
             .last()
-            .and_then(std::option::Option::as_ref)
+            .and_then(Option::as_ref)
             .ok_or(InstructionError::CallDepth)
     }
 

--- a/vendor/solana/program-runtime/src/loaded_programs.rs
+++ b/vendor/solana/program-runtime/src/loaded_programs.rs
@@ -5,6 +5,7 @@ use {
     },
     nostd::{
         collections::BTreeMap,
+        prelude::*,
         sync::{
             atomic::{AtomicU64, Ordering},
             Arc,
@@ -202,6 +203,7 @@ impl LoadProgramMetrics {
         saturating_add_assign!(timings.create_executor_load_elf_us, self.load_elf_us);
         saturating_add_assign!(timings.create_executor_verify_code_us, self.verify_code_us);
         saturating_add_assign!(timings.create_executor_jit_compile_us, self.jit_compile_us);
+        #[cfg(feature = "std")]
         datapoint_trace!(
             "create_executor_trace",
             ("program_id", self.program_id, String),

--- a/vendor/solana/programs/address-lookup-table/src/lib.rs
+++ b/vendor/solana/programs/address-lookup-table/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 

--- a/vendor/solana/programs/address-lookup-table/src/processor.rs
+++ b/vendor/solana/programs/address-lookup-table/src/processor.rs
@@ -1,5 +1,5 @@
 use {
-    core::convert::TryFrom,
+    nostd::prelude::*,
     solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
         address_lookup_table::{

--- a/vendor/solana/programs/bpf_loader/Cargo.toml
+++ b/vendor/solana/programs/bpf_loader/Cargo.toml
@@ -25,6 +25,9 @@ solana-sdk = { workspace = true }
 solana_rbpf = { workspace = true }
 thiserror = { workspace = true }
 
+# workaround
+lazy_static = { version = "1.5", default-features = false, features = ["spin"] }
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 memoffset = { workspace = true }

--- a/vendor/solana/programs/bpf_loader/src/lib.rs
+++ b/vendor/solana/programs/bpf_loader/src/lib.rs
@@ -6,9 +6,9 @@ pub mod serialization;
 pub mod syscalls;
 
 #[cfg(not(feature = "std"))]
-mod single_thread_local;
+mod single_thread;
 #[cfg(not(feature = "std"))]
-use single_thread_local::SingleThreadLocal;
+use single_thread::LocalKey;
 use {
     nostd::{
         cell::RefCell,
@@ -73,7 +73,7 @@ thread_local! {
 
 #[cfg(not(feature = "std"))]
 lazy_static::lazy_static! {
-    pub static ref MEMORY_POOL: SingleThreadLocal<VmMemoryPool> = SingleThreadLocal::new(VmMemoryPool::new());
+    pub static ref MEMORY_POOL: LocalKey<VmMemoryPool> = LocalKey::new(VmMemoryPool::new());
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/vendor/solana/programs/bpf_loader/src/serialization.rs
+++ b/vendor/solana/programs/bpf_loader/src/serialization.rs
@@ -3,6 +3,7 @@
 use {
     byteorder::{ByteOrder, LittleEndian},
     core::mem::{self, size_of},
+    nostd::prelude::*,
     solana_program_runtime::invoke_context::SerializedAccountMetadata,
     solana_rbpf::{
         aligned_memory::{AlignedMemory, Pod},

--- a/vendor/solana/programs/bpf_loader/src/single_thread.rs
+++ b/vendor/solana/programs/bpf_loader/src/single_thread.rs
@@ -1,10 +1,10 @@
 use core::cell::UnsafeCell;
 
-pub struct SingleThreadLocal<T>(UnsafeCell<T>);
+pub struct LocalKey<T>(UnsafeCell<T>);
 
-unsafe impl<T> Sync for SingleThreadLocal<T> {}
+unsafe impl<T> Sync for LocalKey<T> {}
 
-impl<T> SingleThreadLocal<T> {
+impl<T> LocalKey<T> {
     pub const fn new(value: T) -> Self {
         Self(UnsafeCell::new(value))
     }

--- a/vendor/solana/programs/bpf_loader/src/single_thread_local.rs
+++ b/vendor/solana/programs/bpf_loader/src/single_thread_local.rs
@@ -1,0 +1,15 @@
+use core::cell::UnsafeCell;
+
+pub struct SingleThreadLocal<T>(UnsafeCell<T>);
+
+unsafe impl<T> Sync for SingleThreadLocal<T> {}
+
+impl<T> SingleThreadLocal<T> {
+    pub const fn new(value: T) -> Self {
+        Self(UnsafeCell::new(value))
+    }
+
+    pub fn with_borrow_mut<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        unsafe { f(&mut *self.0.get()) }
+    }
+}

--- a/vendor/solana/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/vendor/solana/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
     crate::serialization::account_data_region_memory_state,
+    core::{mem, ptr},
     scopeguard::defer,
     solana_measure::measure::Measure,
     solana_program_runtime::invoke_context::SerializedAccountMetadata,
@@ -17,7 +18,6 @@ use {
         },
         transaction_context::BorrowedAccount,
     },
-    std::{mem, ptr},
 };
 
 fn check_account_info_pointer(
@@ -462,8 +462,8 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
             #[allow(clippy::indexing_slicing)]
             let account_meta = &account_metas[account_index];
             if unsafe {
-                std::ptr::read_volatile(&account_meta.is_signer as *const _ as *const u8) > 1
-                    || std::ptr::read_volatile(&account_meta.is_writable as *const _ as *const u8)
+                core::ptr::read_volatile(&account_meta.is_signer as *const _ as *const u8) > 1
+                    || core::ptr::read_volatile(&account_meta.is_writable as *const _ as *const u8)
                         > 1
             } {
                 return Err(Box::new(InstructionError::InvalidArgument));
@@ -689,8 +689,8 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
             #[allow(clippy::indexing_slicing)]
             let account_meta = &account_metas[account_index];
             if unsafe {
-                std::ptr::read_volatile(&account_meta.is_signer as *const _ as *const u8) > 1
-                    || std::ptr::read_volatile(&account_meta.is_writable as *const _ as *const u8)
+                core::ptr::read_volatile(&account_meta.is_signer as *const _ as *const u8) > 1
+                    || core::ptr::read_volatile(&account_meta.is_writable as *const _ as *const u8)
                         > 1
             } {
                 return Err(Box::new(InstructionError::InvalidArgument));
@@ -1448,7 +1448,7 @@ fn update_caller_account(
             memory_mapping,
             caller_account
                 .vm_data_addr
-                .saturating_sub(std::mem::size_of::<u64>() as u64),
+                .saturating_sub(core::mem::size_of::<u64>() as u64),
             invoke_context.get_check_aligned(),
         )?;
         *serialized_len_ptr = post_len as u64;

--- a/vendor/solana/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/vendor/solana/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -1,7 +1,7 @@
 use {
     super::*,
+    core::slice,
     solana_rbpf::{error::EbpfError, memory_region::MemoryRegion},
-    std::slice,
 };
 
 fn mem_op_consume(invoke_context: &mut InvokeContext, n: u64) -> Result<(), Error> {
@@ -170,7 +170,7 @@ fn memmove(
         )?
         .as_ptr();
 
-        unsafe { std::ptr::copy(src_ptr, dst_ptr, n as usize) };
+        unsafe { core::ptr::copy(src_ptr, dst_ptr, n as usize) };
         Ok(0)
     }
 }
@@ -191,7 +191,7 @@ fn memmove_non_contiguous(
         memory_mapping,
         reverse,
         |src_host_addr, dst_host_addr, chunk_len| {
-            unsafe { std::ptr::copy(src_host_addr, dst_host_addr as *mut u8, chunk_len) };
+            unsafe { core::ptr::copy(src_host_addr, dst_host_addr as *mut u8, chunk_len) };
             Ok(0)
         },
     )
@@ -254,16 +254,16 @@ enum MemcmpError {
     Diff(i32),
 }
 
-impl std::fmt::Display for MemcmpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for MemcmpError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             MemcmpError::Diff(diff) => write!(f, "memcmp diff: {diff}"),
         }
     }
 }
 
-impl std::error::Error for MemcmpError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for MemcmpError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             MemcmpError::Diff(_) => None,
         }

--- a/vendor/solana/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/vendor/solana/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
+fn get_sysvar<T: core::fmt::Debug + Sysvar + SysvarId + Clone>(
     sysvar: Result<Arc<T>, InstructionError>,
     var_addr: u64,
     check_aligned: bool,
@@ -193,7 +193,7 @@ declare_builtin_function!(
             invoke_context,
             sysvar_base_cost
                 .saturating_add(sysvar_id_cost)
-                .saturating_add(std::cmp::max(sysvar_buf_cost, mem_op_base_cost)),
+                .saturating_add(core::cmp::max(sysvar_buf_cost, mem_op_base_cost)),
         )?;
 
         // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."

--- a/vendor/solana/programs/compute-budget/src/lib.rs
+++ b/vendor/solana/programs/compute-budget/src/lib.rs
@@ -1,4 +1,8 @@
-use solana_program_runtime::declare_process_instruction;
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use {alloc::boxed::Box, solana_program_runtime::declare_process_instruction};
 
 pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
 

--- a/vendor/solana/programs/system/src/system_processor.rs
+++ b/vendor/solana/programs/system/src/system_processor.rs
@@ -4,7 +4,7 @@ use {
         withdraw_nonce_account,
     },
     log::*,
-    nostd::collections::HashSet,
+    nostd::{boxed::Box, collections::HashSet},
     solana_program_runtime::{
         declare_process_instruction, ic_msg, invoke_context::InvokeContext,
         sysvar_cache::get_sysvar_with_account_check,


### PR DESCRIPTION
This PR fixes build errors when building `pallet-solana` on wasm32 target with no_std.