### PR TITLE
fix: Add recovery ID check to secp256k1_recover syscall

### DIFF
--- a/vendor/solana/programs/bpf_loader/src/syscalls/mod.rs
+++ b/vendor/solana/programs/bpf_loader/src/syscalls/mod.rs
@@ -882,6 +882,9 @@ declare_builtin_function!(
         let Ok(recovery_id) = recovery_id_val.try_into() else {
             return Ok(Secp256k1RecoverError::InvalidRecoveryId.into());
         };
+        if recovery_id > 3 {
+            return Ok(Secp256k1RecoverError::InvalidRecoveryId.into());
+        }
         if signature.len() != SECP256K1_SIGNATURE_LENGTH {
             return Ok(Secp256k1RecoverError::InvalidSignature.into());
         }


### PR DESCRIPTION
`sp_io::crypto::secp256k1_ecdsa_recover()` accepts recovery ID within not only `0..=3`, but `27..=31`.

To make its behavior align to Solana, this PR updates `secp256k1_recover` syscall to reject the latter range of recovery ID.