### PR TITLE
ci: Fix the rate limit excess with setup-protoc action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**.rs'
       - '**.toml'
+      - '**.yml'
   pull_request:
     paths:
       - '**.rs'
       - '**.toml'
+      - '**.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           submodules: recursive
       - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Check
@@ -36,6 +38,8 @@ jobs:
         with:
           submodules: recursive
       - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Build
@@ -47,6 +51,8 @@ jobs:
         with:
           submodules: recursive
       - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Test


### PR DESCRIPTION
This PR fixes the rate limit excess with `setup-protoc` github action.