### PR TITLE
chore: Switch Cosmos package dependencies from crate to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ enum-iterator = "1.5.0"
 ethereum = { version = "0.15.0", default-features = false }
 futures = "0.3"
 getrandom = { version = "0.2", default-features = false }
+hex = "0.4"
 hex-literal = "0.4"
 impl-trait-for-tuples = { version = "0.2.2" }
 itertools = { version = "0.12.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ bytemuck = "1.16.1"
 bytemuck_derive = "1.7.0"
 byteorder = { version = "1.5.0", default-features = false }
 const-hex = { version = "1.13", default-features = false }
+core2 = { version = "0.4.0", default-features = false }
 cosmos-sdk-proto = { version = "0.24", default-features = false }
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 derive-where = "1.2"
@@ -85,12 +86,13 @@ enum-iterator = "1.5.0"
 ethereum = { version = "0.15.0", default-features = false }
 futures = "0.3"
 getrandom = { version = "0.2", default-features = false }
-hex = "0.4"
+hex = { version = "0.4", default-features = false }
 hex-literal = "0.4"
 impl-trait-for-tuples = { version = "0.2.2" }
 itertools = { version = "0.12.1", default-features = false }
 jsonrpsee = { version = "0.24" }
 k256 = { version = "0.13", default-features = false }
+libflate = { version = "2.1.0", default-features = false }
 libsecp256k1 = { version = "0.6.0", default-features = false }
 light-poseidon = "0.2.0"
 log = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ bytemuck = "1.16.1"
 bytemuck_derive = "1.7.0"
 byteorder = { version = "1.5.0", default-features = false }
 const-hex = { version = "1.13", default-features = false }
-core2 = { version = "0.4.0", default-features = false }
 cosmos-sdk-proto = { version = "0.24", default-features = false }
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 derive-where = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ ethereum = { version = "0.15.0", default-features = false }
 futures = "0.3"
 getrandom = { version = "0.2", default-features = false }
 hex-literal = "0.4"
+impl-trait-for-tuples = { version = "0.2.2" }
 itertools = { version = "0.12.1", default-features = false }
 jsonrpsee = { version = "0.24" }
 k256 = { version = "0.13", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ enum-iterator = "1.5.0"
 ethereum = { version = "0.15.0", default-features = false }
 futures = "0.3"
 getrandom = { version = "0.2", default-features = false }
-hex = { version = "0.4", default-features = false }
 hex-literal = "0.4"
 impl-trait-for-tuples = { version = "0.2.2" }
 itertools = { version = "0.12.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,11 @@ derive-where = "1.2"
 eager = "0.1.0"
 enum-iterator = "1.5.0"
 ethereum = { version = "0.15.0", default-features = false }
+futures = "0.3"
 getrandom = { version = "0.2", default-features = false }
 hex-literal = "0.4"
 itertools = { version = "0.12.1", default-features = false }
+jsonrpsee = { version = "0.24" }
 k256 = { version = "0.13", default-features = false }
 libsecp256k1 = { version = "0.6.0", default-features = false }
 light-poseidon = "0.2.0"
@@ -125,7 +127,9 @@ pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch =
 pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
 sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
 sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }

--- a/frame/cosmos/Cargo.toml
+++ b/frame/cosmos/Cargo.toml
@@ -16,11 +16,11 @@ cosmos-sdk-proto = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 nostd = { workspace = true }
-pallet-cosmos-x-auth-signing = { workspace = true, default-features = false }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-multimap = { workspace = true, default-features = false }
+pallet-cosmos-x-auth-signing = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-multimap = { workspace = true }
 parity-scale-codec = { workspace = true }
-np-cosmos = { workspace = true, default-features = false }
+np-cosmos = { workspace = true }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }

--- a/frame/cosmos/Cargo.toml
+++ b/frame/cosmos/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 cosmos-sdk-proto = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+nostd = { workspace = true }
 pallet-cosmos-x-auth-signing = { workspace = true, default-features = false }
 pallet-cosmos-types = { workspace = true, default-features = false }
 pallet-multimap = { workspace = true, default-features = false }
@@ -30,6 +31,7 @@ std = [
 	"cosmos-sdk-proto/std",
 	"frame-support/std",
 	"frame-system/std",
+	"nostd/std",
 	"pallet-cosmos-x-auth-signing/std",
 	"pallet-cosmos-types/std",
 	"pallet-multimap/std",

--- a/frame/cosmos/rpc/Cargo.toml
+++ b/frame/cosmos/rpc/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "cosmos-rpc"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
-license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+license = "GPL-3.0-or-later"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]

--- a/frame/cosmos/rpc/Cargo.toml
+++ b/frame/cosmos/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-rpc"
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 authors = { workspace = true }
 version = { workspace = true }
 edition = { workspace = true }

--- a/frame/cosmos/rpc/Cargo.toml
+++ b/frame/cosmos/rpc/Cargo.toml
@@ -9,12 +9,11 @@ publish = false
 
 [dependencies]
 cosmos-runtime-api = { workspace = true, features = ["std"] }
-futures = "0.3"
-hex = "0.4.3"
-jsonrpsee = { version = "0.24", features = ["client", "server", "macros"] }
+futures = { workspace = true }
+jsonrpsee = { workspace = true, features = ["client", "server", "macros"] }
 pallet-cosmos-types = { workspace = true, features = ["std"] }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sc-transaction-pool-api = { workspace = true }
+sp-api = { workspace = true, features = ["std"] }
+sp-blockchain = { workspace = true }
+sp-core = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }

--- a/frame/cosmos/rpc/src/cosmos.rs
+++ b/frame/cosmos/rpc/src/cosmos.rs
@@ -91,8 +91,12 @@ where
 			.simulate(at, tx_bytes.to_vec())
 			.map_err(internal_error)?
 			.map_err(|e| match e {
-				SimulateError::InvalidTx => request_error("Invalid tx"),
-				SimulateError::InternalError(e) => internal_error(String::from_utf8_lossy(&e)),
+				SimulateError::InvalidTransaction =>
+					request_error("Simulate transaction failed: Invalid transaction"),
+				SimulateError::InternalError(e) => internal_error(format!(
+					"Simulate transaction failed: {})",
+					String::from_utf8_lossy(&e)
+				)),
 			})
 	}
 

--- a/frame/cosmos/rpc/src/lib.rs
+++ b/frame/cosmos/rpc/src/lib.rs
@@ -17,29 +17,19 @@
 
 pub mod cosmos;
 
-use jsonrpsee::{
-	core::to_json_raw_value,
-	types::{
-		error::{INTERNAL_ERROR_CODE, INVALID_REQUEST_CODE},
-		ErrorObject, ErrorObjectOwned,
-	},
+use jsonrpsee::types::{
+	error::{INTERNAL_ERROR_CODE, INVALID_REQUEST_CODE},
+	ErrorObject, ErrorObjectOwned,
 };
 
-pub fn error<T: ToString>(code: i32, message: T, data: Option<&[u8]>) -> ErrorObjectOwned {
-	ErrorObject::owned(
-		code,
-		message.to_string(),
-		data.map(|bytes| {
-			to_json_raw_value(&format!("0x{}", hex::encode(bytes)))
-				.expect("Failed to serialize data")
-		}),
-	)
+pub fn error<T: ToString>(code: i32, message: T) -> ErrorObjectOwned {
+	ErrorObject::owned(code, message.to_string(), None::<()>)
 }
 
 pub fn request_error<T: ToString>(message: T) -> ErrorObjectOwned {
-	error(INVALID_REQUEST_CODE, message, None)
+	error(INVALID_REQUEST_CODE, message)
 }
 
 pub fn internal_error<T: ToString>(message: T) -> ErrorObjectOwned {
-	error(INTERNAL_ERROR_CODE, message, None)
+	error(INTERNAL_ERROR_CODE, message)
 }

--- a/frame/cosmos/runtime-api/Cargo.toml
+++ b/frame/cosmos/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos-runtime-api"
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 authors = { workspace = true }
 version = { workspace = true }
 edition = { workspace = true }

--- a/frame/cosmos/runtime-api/Cargo.toml
+++ b/frame/cosmos/runtime-api/Cargo.toml
@@ -8,16 +8,18 @@ repository = "https://github.com/noirhq/noir.git"
 publish = false
 
 [dependencies]
-pallet-cosmos-types = { workspace = true, default-features = false }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0.210", default-features = false, features = ["derive"] }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+nostd = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+sp-api = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
+	"nostd/std",
 	"pallet-cosmos-types/std",
 	"parity-scale-codec/std",
 	"scale-info/std",

--- a/frame/cosmos/runtime-api/Cargo.toml
+++ b/frame/cosmos/runtime-api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "cosmos-runtime-api"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
-license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+license = "GPL-3.0-or-later"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]

--- a/frame/cosmos/runtime-api/src/lib.rs
+++ b/frame/cosmos/runtime-api/src/lib.rs
@@ -17,9 +17,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
-use alloc::{string::String, vec::Vec};
+use nostd::{string::String, vec::Vec};
 use pallet_cosmos_types::tx::SimulateResponse;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -29,7 +27,7 @@ use sp_runtime::traits::Block as BlockT;
 
 #[derive(Clone, Decode, Encode, Debug, Eq, PartialEq, TypeInfo)]
 pub enum SimulateError {
-	InvalidTx,
+	InvalidTransaction,
 	InternalError(Vec<u8>),
 }
 

--- a/frame/cosmos/src/lib.rs
+++ b/frame/cosmos/src/lib.rs
@@ -18,8 +18,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(unreachable_patterns)]
 
-extern crate alloc;
-
 pub mod types;
 pub mod weights;
 
@@ -138,7 +136,6 @@ pub trait AddressMapping<A> {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use alloc::{string::String, vec::Vec};
 	use cosmos_sdk_proto::Any;
 	use frame_support::{
 		dispatch::WithPostDispatchInfo,
@@ -148,6 +145,7 @@ pub mod pallet {
 			Contains, Currency,
 		},
 	};
+	use nostd::{string::String, vec::Vec};
 	use np_cosmos::traits::ChainInfo;
 	use pallet_cosmos_types::{
 		context::traits::MinGasPrices, errors::CosmosError, events::CosmosEvent, gas::Gas,

--- a/frame/cosmos/src/weights.rs
+++ b/frame/cosmos/src/weights.rs
@@ -15,9 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::marker::PhantomData;
 use frame_support::{dispatch::DispatchClass, weights::Weight};
 use frame_system::limits::BlockWeights;
+use nostd::marker::PhantomData;
 use sp_core::Get;
 
 pub trait WeightInfo {
@@ -30,8 +30,8 @@ impl WeightInfo for () {
 	}
 }
 
-pub struct CosmosWeight<T>(PhantomData<T>);
-impl<T> WeightInfo for CosmosWeight<T>
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T> WeightInfo for SubstrateWeight<T>
 where
 	T: frame_system::Config,
 {

--- a/frame/cosmos/types/Cargo.toml
+++ b/frame/cosmos/types/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true, features = ["derive"] }
 sp-runtime = { workspace = true }
 
 [dev-dependencies]
-hex = { workspace = true }
+hex = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/types/Cargo.toml
+++ b/frame/cosmos/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-cosmos-types"
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 authors = { workspace = true }
 version = { workspace = true }
 edition = { workspace = true }
@@ -19,7 +19,7 @@ serde = { workspace = true, features = ["derive"] }
 sp-runtime = { workspace = true }
 
 [dev-dependencies]
-hex = "0.4"
+hex = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/types/Cargo.toml
+++ b/frame/cosmos/types/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true, features = ["derive"] }
 sp-runtime = { workspace = true }
 
 [dev-dependencies]
-hex = { workspace = true, features = ["std"] }
+const-hex = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/types/Cargo.toml
+++ b/frame/cosmos/types/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "pallet-cosmos-types"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
-license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+license = "GPL-3.0-or-later"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-bech32 = { version = "0.11", default-features = false, features = ["alloc"] }
-cosmos-sdk-proto = { version = "0.24", default-features = false, features = ["cosmwasm"] }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-impl-trait-for-tuples = { version = "0.2.2" }
-parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
-scale-info = { version = "2.11", default-features = false, features = ["derive"] }
-serde = { version = "1.0.210", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+bech32 = { workspace = true, features = ["alloc"] }
+cosmos-sdk-proto = { workspace = true, features = ["cosmwasm"] }
+frame-support = { workspace = true }
+impl-trait-for-tuples = { workspace = true }
+nostd = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/frame/cosmos/types/src/address.rs
+++ b/frame/cosmos/types/src/address.rs
@@ -41,7 +41,7 @@ mod tests {
 		let (hrp, address_raw) = acc_address_from_bech32(address).unwrap();
 		assert_eq!(hrp, "cosmos");
 
-		let address_raw = hex::encode(address_raw);
+		let address_raw = const_hex::encode(address_raw);
 		assert_eq!(address_raw, "037459f1d22d10bed7b6920865c8bc96c5571f2d");
 	}
 }

--- a/frame/cosmos/types/src/address.rs
+++ b/frame/cosmos/types/src/address.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{
+use nostd::{
 	string::{String, ToString},
 	vec::Vec,
 };

--- a/frame/cosmos/types/src/coin/mod.rs
+++ b/frame/cosmos/types/src/coin/mod.rs
@@ -17,7 +17,7 @@
 
 pub mod traits;
 
-use alloc::{
+use nostd::{
 	string::{String, ToString},
 	vec::Vec,
 };

--- a/frame/cosmos/types/src/coin/traits.rs
+++ b/frame/cosmos/types/src/coin/traits.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::string::String;
+use nostd::string::String;
 
 pub trait Coins {
 	type Error;

--- a/frame/cosmos/types/src/context/traits.rs
+++ b/frame/cosmos/types/src/context/traits.rs
@@ -20,7 +20,7 @@ use crate::{
 	events::traits::EventManager,
 	gas::{traits::GasMeter, Gas},
 };
-use alloc::vec::Vec;
+use nostd::vec::Vec;
 
 pub trait Context {
 	type GasMeter: GasMeter;

--- a/frame/cosmos/types/src/events/mod.rs
+++ b/frame/cosmos/types/src/events/mod.rs
@@ -17,7 +17,7 @@
 
 pub mod traits;
 
-use alloc::vec::Vec;
+use nostd::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};

--- a/frame/cosmos/types/src/lib.rs
+++ b/frame/cosmos/types/src/lib.rs
@@ -17,8 +17,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod address;
 pub mod coin;
 pub mod context;

--- a/frame/cosmos/types/src/msgservice/traits.rs
+++ b/frame/cosmos/types/src/msgservice/traits.rs
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 use crate::errors::CosmosError;
-use alloc::boxed::Box;
 use cosmos_sdk_proto::Any;
+use nostd::boxed::Box;
 
 pub trait MsgHandler<Context> {
 	fn handle(&self, ctx: &mut Context, msg: &Any) -> Result<(), CosmosError>;

--- a/frame/cosmos/types/src/tx_msgs.rs
+++ b/frame/cosmos/types/src/tx_msgs.rs
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 use crate::gas::Gas;
-use alloc::{string::String, vec::Vec};
 use cosmos_sdk_proto::cosmos::tx::v1beta1::{Fee, Tx};
+use nostd::{string::String, vec::Vec};
 
 pub trait Msg {
 	// get_signers returns the addresses of signers that must sign.
@@ -35,12 +35,15 @@ impl FeeTx for Tx {
 	fn fee(&self) -> Option<Fee> {
 		self.auth_info.as_ref().and_then(|auth_info| auth_info.fee.clone())
 	}
+
 	fn gas(&self) -> Option<Gas> {
 		self.fee().map(|fee| fee.gas_limit)
 	}
+
 	fn fee_payer(&self) -> Option<String> {
 		self.fee().map(|fee| fee.payer.clone())
 	}
+	
 	fn fee_granter(&self) -> Option<String> {
 		self.fee().map(|fee| fee.granter.clone())
 	}

--- a/frame/cosmos/types/src/tx_msgs.rs
+++ b/frame/cosmos/types/src/tx_msgs.rs
@@ -43,7 +43,7 @@ impl FeeTx for Tx {
 	fn fee_payer(&self) -> Option<String> {
 		self.fee().map(|fee| fee.payer.clone())
 	}
-	
+
 	fn fee_granter(&self) -> Option<String> {
 		self.fee().map(|fee| fee.granter.clone())
 	}

--- a/frame/cosmos/x/auth/Cargo.toml
+++ b/frame/cosmos/x/auth/Cargo.toml
@@ -1,27 +1,28 @@
 [package]
 name = "pallet-cosmos-x-auth"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-np-cosmos = { workspace = true, default-features = false }
-pallet-cosmos = { workspace = true, default-features = false }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-cosmos-x-auth-signing = { workspace = true, default-features = false }
-ripemd = { version = "0.1.3", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+cosmos-sdk-proto = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+nostd = { workspace = true }
+np-cosmos = { workspace = true }
+pallet-cosmos = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-cosmos-x-auth-signing = { workspace = true }
+ripemd = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
-const-hex = "1.13"
+const-hex = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/x/auth/migrations/Cargo.toml
+++ b/frame/cosmos/x/auth/migrations/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "pallet-cosmos-x-auth-migrations"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false }
-pallet-cosmos-types = { workspace = true, default-features = false }
-serde = { version = "1.0.210", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.127", default-features = false }
+cosmos-sdk-proto = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+nostd = { workspace = true }
 
 [features]
 default = ["std"]
@@ -20,4 +21,5 @@ std = [
     "pallet-cosmos-types/std",
     "serde/std",
     "serde_json/std",
+    "nostd/std",
 ]

--- a/frame/cosmos/x/auth/migrations/src/legacytx/stdsign.rs
+++ b/frame/cosmos/x/auth/migrations/src/legacytx/stdsign.rs
@@ -15,11 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cosmos_sdk_proto::cosmos::tx::v1beta1::Fee;
 use nostd::{
 	string::{String, ToString},
 	vec::Vec,
 };
-use cosmos_sdk_proto::cosmos::tx::v1beta1::Fee;
 use pallet_cosmos_types::coin::Coin;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/frame/cosmos/x/auth/migrations/src/legacytx/stdsign.rs
+++ b/frame/cosmos/x/auth/migrations/src/legacytx/stdsign.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{
+use nostd::{
 	string::{String, ToString},
 	vec::Vec,
 };

--- a/frame/cosmos/x/auth/migrations/src/lib.rs
+++ b/frame/cosmos/x/auth/migrations/src/lib.rs
@@ -17,6 +17,4 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod legacytx;

--- a/frame/cosmos/x/auth/signing/Cargo.toml
+++ b/frame/cosmos/x/auth/signing/Cargo.toml
@@ -1,37 +1,34 @@
 [package]
 name = "pallet-cosmos-x-auth-signing"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false, features = [
-	"cosmwasm",
-] }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-cosmos-x-auth-migrations = { workspace = true, default-features = false }
-pallet-cosmos-x-bank-types = { workspace = true, default-features = false }
-pallet-cosmos-x-wasm-types = { workspace = true, default-features = false }
-serde_json = { version = "1.0.127", default-features = false }
+cosmos-sdk-proto = { workspace = true, features = ["cosmwasm"] }
+nostd = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-cosmos-x-auth-migrations = { workspace = true }
+pallet-cosmos-x-bank-types = { workspace = true }
+pallet-cosmos-x-wasm-types = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-base64ct = { version = "1.6.0", default-features = false }
-hex = { version = "0.4.3", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+base64 = { workspace = true, features = ["std"] }
+hex = { workspace = true }
+sp-core = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]
 std = [
 	"cosmos-sdk-proto/std",
+	"nostd/std",
 	"pallet-cosmos-types/std",
 	"pallet-cosmos-x-auth-migrations/std",
 	"pallet-cosmos-x-bank-types/std",
 	"pallet-cosmos-x-wasm-types/std",
 	"serde_json/std",
-	"base64ct/std",
-	"hex/std",
-	"sp-core/std",
 ]

--- a/frame/cosmos/x/auth/signing/Cargo.toml
+++ b/frame/cosmos/x/auth/signing/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = { workspace = true, features = ["std"] }
-hex = { workspace = true }
+const-hex = { workspace = true, features = ["std"] }
 sp-core = { workspace = true, features = ["std"] }
 
 [features]

--- a/frame/cosmos/x/auth/signing/src/lib.rs
+++ b/frame/cosmos/x/auth/signing/src/lib.rs
@@ -17,7 +17,5 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod sign_mode_handler;
 pub mod sign_verifiable_tx;

--- a/frame/cosmos/x/auth/signing/src/sign_mode_handler/mod.rs
+++ b/frame/cosmos/x/auth/signing/src/sign_mode_handler/mod.rs
@@ -17,10 +17,6 @@
 
 pub mod traits;
 
-use alloc::{
-	string::{String, ToString},
-	vec::Vec,
-};
 use cosmos_sdk_proto::{
 	cosmos::{
 		bank,
@@ -35,6 +31,10 @@ use cosmos_sdk_proto::{
 	cosmwasm::wasm,
 	traits::Message,
 	Any,
+};
+use nostd::{
+	string::{String, ToString},
+	vec::Vec,
 };
 use pallet_cosmos_types::{any_match, tx_msgs::FeeTx};
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::{LegacyMsg, StdSignDoc};
@@ -132,7 +132,7 @@ impl traits::SignModeHandler for SignModeHandler {
 #[cfg(test)]
 mod tests {
 	use crate::sign_mode_handler::{traits::SignModeHandler as _, SignModeHandler, SignerData};
-	use base64ct::{Base64, Encoding};
+	use base64::{prelude::BASE64_STANDARD, Engine};
 	use cosmos_sdk_proto::{
 		cosmos::tx::v1beta1::{
 			mode_info::{Single, Sum},
@@ -146,7 +146,7 @@ mod tests {
 	fn get_sign_bytes_test() {
 		let tx_raw = "CpMBCpABChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEnAKLWNvc21vczFxZDY5bnV3ajk1Z3RhNGFramd5eHRqOXVqbXo0dzhlZG1xeXNxdxItY29zbW9zMWdtajJleGFnMDN0dGdhZnBya2RjM3Q4ODBncm1hOW53ZWZjZDJ3GhAKBXVhdG9tEgcxMDAwMDAwEnEKTgpGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQIKEJE0H+VmS/oXgtXgR3lokGjJFrBMs2XsMVN1VoTZoRIECgIIARIfChUKBXVhdG9tEgw4ODY4ODAwMDAwMDAQgMDxxZSVFBpA9+DRmMYoIcxYF8jpNfUjMIMB4pgZ9diC8ySbnhc6YU84AA3b/0RsCr+nx9AZ27FwcrKJM/yBh8lz+/A9BFn3bg==";
 
-		let tx_raw = Base64::decode_vec(tx_raw).unwrap();
+		let tx_raw = BASE64_STANDARD.decode(tx_raw).unwrap();
 		let tx = Tx::decode(&mut &*tx_raw).unwrap();
 
 		let public_key = tx
@@ -172,7 +172,7 @@ mod tests {
 
 		let sign_doc_raw =
 		"CpMBCpABChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEnAKLWNvc21vczFxZDY5bnV3ajk1Z3RhNGFramd5eHRqOXVqbXo0dzhlZG1xeXNxdxItY29zbW9zMWdtajJleGFnMDN0dGdhZnBya2RjM3Q4ODBncm1hOW53ZWZjZDJ3GhAKBXVhdG9tEgcxMDAwMDAwEnEKTgpGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQIKEJE0H+VmS/oXgtXgR3lokGjJFrBMs2XsMVN1VoTZoRIECgIIARIfChUKBXVhdG9tEgw4ODY4ODAwMDAwMDAQgMDxxZSVFBoRdGhldGEtdGVzdG5ldC0wMDEgrYou";
-		let hash = sha2_256(&Base64::decode_vec(sign_doc_raw).unwrap());
+		let hash = sha2_256(&BASE64_STANDARD.decode(sign_doc_raw).unwrap());
 
 		assert_eq!(expected_hash, hash);
 	}
@@ -180,7 +180,7 @@ mod tests {
 	#[test]
 	fn get_std_sign_bytes_test() {
 		let tx_raw =  "CpoBCpcBChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEncKLWNvc21vczFxZDY5bnV3ajk1Z3RhNGFramd5eHRqOXVqbXo0dzhlZG1xeXNxdxItY29zbW9zMW41amd4NjR6dzM4c3M3Nm16dXU0dWM3amV5cXcydmZqazYwZmR6GhcKBGFjZHQSDzEwMDAwMDAwMDAwMDAwMBJsCk4KRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiECChCRNB/lZkv6F4LV4Ed5aJBoyRawTLNl7DFTdVaE2aESBAoCCH8SGgoSCgRhY2R0EgoxMDQwMDAwMDAwEIDa8esEGkBgXIiPoBpecG7QpKDJPaztFogqvmxjDHF5ORfWBrOoSzf0+AAmch1CXrG4OmiKL0y8v9ITx0QzWYUc7ueXcdIm";
-		let tx_raw = Base64::decode_vec(tx_raw).unwrap();
+		let tx_raw = BASE64_STANDARD.decode(tx_raw).unwrap();
 		let tx = Tx::decode(&mut &*tx_raw).unwrap();
 
 		let public_key = tx

--- a/frame/cosmos/x/auth/signing/src/sign_mode_handler/mod.rs
+++ b/frame/cosmos/x/auth/signing/src/sign_mode_handler/mod.rs
@@ -203,7 +203,7 @@ mod tests {
 			pub_key: public_key.clone(),
 		};
 		let hash = sha2_256(&SignModeHandler::get_sign_bytes(&mode, &data, &tx).unwrap());
-		let hash = hex::encode(hash);
+		let hash = const_hex::encode(hash);
 
 		assert_eq!(hash, "714d4bdfdbd0bd630ebdf93b1f6eba7d3c752e92bbab6c9d3d9c93e1777348bb");
 	}

--- a/frame/cosmos/x/auth/signing/src/sign_mode_handler/traits.rs
+++ b/frame/cosmos/x/auth/signing/src/sign_mode_handler/traits.rs
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 use super::{SignModeHandlerError, SignerData};
-use alloc::vec::Vec;
 use cosmos_sdk_proto::cosmos::tx::v1beta1::{ModeInfo, Tx};
+use nostd::vec::Vec;
 
 pub trait SignModeHandler {
 	fn get_sign_bytes(

--- a/frame/cosmos/x/auth/signing/src/sign_verifiable_tx/mod.rs
+++ b/frame/cosmos/x/auth/signing/src/sign_verifiable_tx/mod.rs
@@ -17,11 +17,11 @@
 
 pub mod traits;
 
-use alloc::{string::String, vec::Vec};
 use cosmos_sdk_proto::{
 	cosmos::{bank, tx::v1beta1::Tx},
 	cosmwasm::wasm,
 };
+use nostd::{string::String, vec::Vec};
 use pallet_cosmos_types::{
 	any_match,
 	tx_msgs::{FeeTx, Msg},

--- a/frame/cosmos/x/auth/signing/src/sign_verifiable_tx/traits.rs
+++ b/frame/cosmos/x/auth/signing/src/sign_verifiable_tx/traits.rs
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 use super::SigVerifiableTxError;
-use alloc::{string::String, vec::Vec};
 use cosmos_sdk_proto::cosmos::tx::v1beta1::Tx;
+use nostd::{string::String, vec::Vec};
 
 pub trait SigVerifiableTx {
 	fn get_signers(tx: &Tx) -> Result<Vec<String>, SigVerifiableTxError>;

--- a/frame/cosmos/x/auth/src/basic.rs
+++ b/frame/cosmos/x/auth/src/basic.rs
@@ -15,9 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::marker::PhantomData;
 use cosmos_sdk_proto::cosmos::tx::v1beta1::Tx;
 use frame_support::{ensure, traits::Get};
+use nostd::marker::PhantomData;
 use pallet_cosmos_types::{
 	errors::{CosmosError, RootError},
 	handler::AnteDecorator,

--- a/frame/cosmos/x/auth/src/fee.rs
+++ b/frame/cosmos/x/auth/src/fee.rs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::vec;
 use core::marker::PhantomData;
 use cosmos_sdk_proto::cosmos::tx::v1beta1::{Fee, Tx};
 use frame_support::{
@@ -26,6 +25,7 @@ use frame_support::{
 		Currency, ExistenceRequirement, WithdrawReasons,
 	},
 };
+use nostd::vec;
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
 	address::acc_address_from_bech32,

--- a/frame/cosmos/x/auth/src/lib.rs
+++ b/frame/cosmos/x/auth/src/lib.rs
@@ -17,8 +17,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod basic;
 pub mod fee;
 pub mod msg;

--- a/frame/cosmos/x/auth/src/msg.rs
+++ b/frame/cosmos/x/auth/src/msg.rs
@@ -15,9 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::marker::PhantomData;
 use cosmos_sdk_proto::cosmos::tx::v1beta1::Tx;
 use frame_support::{ensure, traits::Contains};
+use nostd::marker::PhantomData;
 use pallet_cosmos_types::{
 	errors::{CosmosError, RootError},
 	handler::AnteDecorator,

--- a/frame/cosmos/x/auth/src/sigverify.rs
+++ b/frame/cosmos/x/auth/src/sigverify.rs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::vec::Vec;
 use core::{cmp::Ordering, marker::PhantomData};
 use cosmos_sdk_proto::{
 	cosmos::{
@@ -26,6 +25,7 @@ use cosmos_sdk_proto::{
 	Any,
 };
 use frame_support::ensure;
+use nostd::vec::Vec;
 use np_cosmos::traits::ChainInfo;
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{

--- a/frame/cosmos/x/bank/Cargo.toml
+++ b/frame/cosmos/x/bank/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "pallet-cosmos-x-bank"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-cosmos = { workspace = true, default-features = false }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-cosmos-x-bank-types = { workspace = true, default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+cosmos-sdk-proto = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+nostd = { workspace = true }
+pallet-cosmos = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-cosmos-x-bank-types = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
@@ -23,6 +24,7 @@ std = [
     "cosmos-sdk-proto/std",
     "frame-support/std",
     "frame-system/std",
+    "nostd/std",
     "pallet-cosmos/std",
     "pallet-cosmos-types/std",
     "pallet-cosmos-x-bank-types/std",

--- a/frame/cosmos/x/bank/src/lib.rs
+++ b/frame/cosmos/x/bank/src/lib.rs
@@ -17,12 +17,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod gas;
 
-use alloc::vec;
-use core::marker::PhantomData;
 use cosmos_sdk_proto::{cosmos::bank::v1beta1::MsgSend, prost::Message, Any};
 use frame_support::{
 	ensure,
@@ -33,6 +29,7 @@ use frame_support::{
 	},
 };
 use gas::GasInfo;
+use nostd::{marker::PhantomData, vec};
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
 	address::acc_address_from_bech32,

--- a/frame/cosmos/x/bank/types/Cargo.toml
+++ b/frame/cosmos/x/bank/types/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "pallet-cosmos-x-bank-types"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-cosmos-x-auth-migrations = { workspace = true, default-features = false }
-serde = { version = "1.0.210", default-features = false, features = ["derive"] }
+cosmos-sdk-proto = { workspace = true }
+nostd = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-cosmos-x-auth-migrations = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = [
 	"cosmos-sdk-proto/std",
+	"nostd/std",
 	"pallet-cosmos-types/std",
 	"pallet-cosmos-x-auth-migrations/std",
 	"serde/std",

--- a/frame/cosmos/x/bank/types/src/lib.rs
+++ b/frame/cosmos/x/bank/types/src/lib.rs
@@ -17,7 +17,5 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod events;
 pub mod msgs;

--- a/frame/cosmos/x/bank/types/src/msgs/msg_send.rs
+++ b/frame/cosmos/x/bank/types/src/msgs/msg_send.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec, vec::Vec};
 use cosmos_sdk_proto::{prost::Message, Any};
+use nostd::{string::String, vec, vec::Vec};
 use pallet_cosmos_types::{coin::Coin, tx_msgs::Msg};
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::LegacyMsg;
 use serde::{Deserialize, Serialize};

--- a/frame/cosmos/x/wasm/Cargo.toml
+++ b/frame/cosmos/x/wasm/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "pallet-cosmos-x-wasm"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-core2 = { version = "0.4.0", default-features = false, features = ["alloc"] }
-cosmos-sdk-proto = { version = "0.24", default-features = false, features = ["cosmwasm"] }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-hex = { version = "0.4.3", default-features = false }
-libflate = { version = "2.1.0", default-features = false }
-log = { version = "0.4.21", default-features = false }
-pallet-cosmos = { workspace = true, default-features = false }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-cosmos-x-wasm-types = { workspace = true, default-features = false }
-pallet-cosmwasm = { workspace = true, default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+core2 = { workspace = true, features = ["alloc"] }
+cosmos-sdk-proto = { workspace = true, features = ["cosmwasm"] }
+frame-support = { workspace = true }
+hex = { workspace = true }
+libflate = { workspace = true }
+log = { workspace = true }
+pallet-cosmos = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-cosmos-x-wasm-types = { workspace = true }
+pallet-cosmwasm = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/cosmos/x/wasm/Cargo.toml
+++ b/frame/cosmos/x/wasm/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 core2 = { workspace = true, features = ["alloc"] }
 cosmos-sdk-proto = { workspace = true, features = ["cosmwasm"] }
 frame-support = { workspace = true }
-hex = { workspace = true }
+const-hex = { workspace = true }
 libflate = { workspace = true }
 log = { workspace = true }
 pallet-cosmos = { workspace = true }
@@ -27,7 +27,7 @@ std = [
 	"core2/std",
 	"cosmos-sdk-proto/std",
 	"frame-support/std",
-	"hex/std",
+	"const-hex/std",
 	"libflate/std",
 	"log/std",
 	"pallet-cosmos/std",

--- a/frame/cosmos/x/wasm/Cargo.toml
+++ b/frame/cosmos/x/wasm/Cargo.toml
@@ -8,12 +8,12 @@ repository = { workspace = true }
 publish = false
 
 [dependencies]
-core2 = { workspace = true, features = ["alloc"] }
 cosmos-sdk-proto = { workspace = true, features = ["cosmwasm"] }
 frame-support = { workspace = true }
 const-hex = { workspace = true }
 libflate = { workspace = true }
 log = { workspace = true }
+nostd = { workspace = true }
 pallet-cosmos = { workspace = true }
 pallet-cosmos-types = { workspace = true }
 pallet-cosmos-x-wasm-types = { workspace = true }
@@ -24,12 +24,12 @@ sp-runtime = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"core2/std",
 	"cosmos-sdk-proto/std",
 	"frame-support/std",
 	"const-hex/std",
 	"libflate/std",
 	"log/std",
+	"nostd/std",
 	"pallet-cosmos/std",
 	"pallet-cosmos-types/std",
 	"pallet-cosmos-x-wasm-types/std",

--- a/frame/cosmos/x/wasm/src/msgs.rs
+++ b/frame/cosmos/x/wasm/src/msgs.rs
@@ -18,7 +18,6 @@
 use crate::error::handle_vm_error;
 use alloc::{string::ToString, vec, vec::Vec};
 use core::{marker::PhantomData, str::FromStr};
-use core2::io::Read;
 use cosmos_sdk_proto::{
 	cosmos::base::v1beta1::Coin,
 	cosmwasm::wasm::v1::{
@@ -30,6 +29,7 @@ use cosmos_sdk_proto::{
 };
 use frame_support::ensure;
 use libflate::gzip::Decoder;
+use nostd::io::Read;
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
 	address::acc_address_from_bech32,

--- a/frame/cosmos/x/wasm/src/msgs.rs
+++ b/frame/cosmos/x/wasm/src/msgs.rs
@@ -105,7 +105,7 @@ where
 				},
 				EventAttribute {
 					key: ATTRIBUTE_KEY_CHECKSUM.into(),
-					value: hex::encode(code_hash.0).into(),
+					value: const_hex::encode(code_hash.0).into(),
 				},
 			],
 		};

--- a/frame/cosmos/x/wasm/types/Cargo.toml
+++ b/frame/cosmos/x/wasm/types/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "pallet-cosmos-x-wasm-types"
-version = "0.4.0"
-authors = ["Haderech Pte. Ltd."]
-edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/noirhq/noir.git"
+authors = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
 publish = false
 
 [dependencies]
-cosmos-sdk-proto = { version = "0.24", default-features = false, features = [
-	"cosmwasm",
-] }
-pallet-cosmos-types = { workspace = true, default-features = false }
-pallet-cosmos-x-auth-migrations = { workspace = true, default-features = false }
-serde = { version = "1.0.210", default-features = false, features = ["derive"] }
+cosmos-sdk-proto = { workspace = true, features = ["cosmwasm"] }
+nostd = { workspace = true }
+pallet-cosmos-types = { workspace = true }
+pallet-cosmos-x-auth-migrations = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = [
 	"cosmos-sdk-proto/std",
+	"nostd/std",
 	"pallet-cosmos-types/std",
 	"pallet-cosmos-x-auth-migrations/std",
 	"serde/std",

--- a/frame/cosmos/x/wasm/types/src/lib.rs
+++ b/frame/cosmos/x/wasm/types/src/lib.rs
@@ -17,8 +17,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod errors;
 pub mod events;
 pub mod tx;

--- a/frame/cosmos/x/wasm/types/src/tx/msg_execute_contract.rs
+++ b/frame/cosmos/x/wasm/types/src/tx/msg_execute_contract.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec, vec::Vec};
 use cosmos_sdk_proto::{prost::Message, Any};
+use nostd::{string::String, vec, vec::Vec};
 use pallet_cosmos_types::{coin::Coin, tx_msgs::Msg};
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::LegacyMsg;
 use serde::{Deserialize, Serialize};

--- a/frame/cosmos/x/wasm/types/src/tx/msg_instantiate_contract2.rs
+++ b/frame/cosmos/x/wasm/types/src/tx/msg_instantiate_contract2.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec, vec::Vec};
 use cosmos_sdk_proto::{prost::Message, Any};
+use nostd::{string::String, vec, vec::Vec};
 use pallet_cosmos_types::{coin::Coin, tx_msgs::Msg};
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::LegacyMsg;
 use serde::{Deserialize, Serialize};

--- a/frame/cosmos/x/wasm/types/src/tx/msg_migrate_contract.rs
+++ b/frame/cosmos/x/wasm/types/src/tx/msg_migrate_contract.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec, vec::Vec};
 use cosmos_sdk_proto::{prost::Message, Any};
+use nostd::{string::String, vec, vec::Vec};
 use pallet_cosmos_types::tx_msgs::Msg;
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::LegacyMsg;
 use serde::{Deserialize, Serialize};

--- a/frame/cosmos/x/wasm/types/src/tx/msg_store_code.rs
+++ b/frame/cosmos/x/wasm/types/src/tx/msg_store_code.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec, vec::Vec};
 use cosmos_sdk_proto::{prost::Message, Any};
+use nostd::{string::String, vec, vec::Vec};
 use pallet_cosmos_types::tx_msgs::Msg;
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::LegacyMsg;
 use serde::{Deserialize, Serialize};

--- a/frame/cosmos/x/wasm/types/src/tx/msg_update_admin.rs
+++ b/frame/cosmos/x/wasm/types/src/tx/msg_update_admin.rs
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec, vec::Vec};
 use cosmos_sdk_proto::{prost::Message, Any};
+use nostd::{string::String, vec, vec::Vec};
 use pallet_cosmos_types::tx_msgs::Msg;
 use pallet_cosmos_x_auth_migrations::legacytx::stdsign::LegacyMsg;
 use serde::{Deserialize, Serialize};

--- a/primitives/cosmos/Cargo.toml
+++ b/primitives/cosmos/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 [dependencies]
 bech32 = { workspace = true, optional = true }
 buidl = { workspace = true }
+nostd = { workspace = true }
 parity-scale-codec = { workspace = true }
 ripemd = { workspace = true }
 scale-info = { workspace = true }
@@ -20,13 +21,14 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 
 [dev-dependencies]
-const-hex = { workspace = true }
+const-hex = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]
 std = [
 	"bech32/std",
 	"buidl/std",
+	"nostd/std",
 	"parity-scale-codec/std",
 	"ripemd/std",
 	"scale-info/std",

--- a/primitives/cosmos/src/lib.rs
+++ b/primitives/cosmos/src/lib.rs
@@ -19,18 +19,15 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-
 pub mod traits;
 
 #[cfg(feature = "serde")]
 use crate::traits::ChainInfo;
 use crate::traits::CosmosHub;
-use alloc::string::String;
 #[cfg(feature = "serde")]
 use bech32::{Bech32, Hrp};
 use buidl::FixedBytes;
-use core::marker::PhantomData;
+use nostd::{marker::PhantomData, string::String};
 use parity_scale_codec::{Decode, Encode};
 use ripemd::{Digest, Ripemd160};
 #[cfg(feature = "serde")]
@@ -65,21 +62,21 @@ impl<T> From<ecdsa::Public> for Address<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<T: ChainInfo> core::fmt::Display for Address<T> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl<T: ChainInfo> nostd::fmt::Display for Address<T> {
+	fn fmt(&self, f: &mut nostd::fmt::Formatter) -> nostd::fmt::Result {
 		let hrp = Hrp::parse_unchecked(T::bech32_prefix());
 		write!(f, "{}", bech32::encode::<Bech32>(hrp, &self.0).expect("bech32 encode"))
 	}
 }
 
-impl<T> core::fmt::Debug for Address<T> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl<T> nostd::fmt::Debug for Address<T> {
+	fn fmt(&self, f: &mut nostd::fmt::Formatter) -> nostd::fmt::Result {
 		write!(f, "{}", sp_core::hexdisplay::HexDisplay::from(&self.0))
 	}
 }
 
 #[cfg(feature = "serde")]
-impl<T: ChainInfo> core::str::FromStr for Address<T> {
+impl<T: ChainInfo> nostd::str::FromStr for Address<T> {
 	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -98,7 +95,7 @@ impl<T: ChainInfo> Serialize for Address<T> {
 	where
 		S: serde::Serializer,
 	{
-		use alloc::string::ToString;
+		use nostd::string::ToString;
 		serializer.serialize_str(&self.to_string())
 	}
 }
@@ -109,7 +106,7 @@ impl<'de, T: ChainInfo> Deserialize<'de> for Address<T> {
 	where
 		D: serde::Deserializer<'de>,
 	{
-		use core::str::FromStr;
+		use nostd::str::FromStr;
 		let s = String::deserialize(deserializer)?;
 		Address::from_str(&s).map_err(serde::de::Error::custom)
 	}

--- a/vendor/composable/cosmwasm/Cargo.toml
+++ b/vendor/composable/cosmwasm/Cargo.toml
@@ -44,7 +44,7 @@ composable-support = { workspace = true, default-features = false }
 cosmwasm-std = { workspace = true, default-features = false, features = [
     "iterator",
     "stargate",
-    "cosmwasm_1_4",
+    "cosmwasm_1_2",
 ] }
 cosmwasm-vm = { workspace = true, default-features = false, features = [
     "iterator",

--- a/vendor/composable/vm-wasmi/Cargo.toml
+++ b/vendor/composable/vm-wasmi/Cargo.toml
@@ -22,7 +22,7 @@ wasm-instrument = { version = "0.4.0", default-features = false }
 cosmwasm-std = { workspace = true, default-features = false, features = [
 	"iterator",
 	"stargate",
-	"cosmwasm_1_4",
+	"cosmwasm_1_2",
 ] }
 cosmwasm-vm = { workspace = true, default-features = false, features = [
 	"iterator",

--- a/vendor/composable/vm/Cargo.toml
+++ b/vendor/composable/vm/Cargo.toml
@@ -13,7 +13,7 @@ std = ["cosmwasm-std/std"]
 cosmwasm-std = { workspace = true, default-features = false, features = [
   "iterator",
   "stargate",
-  "cosmwasm_1_4",
+  "cosmwasm_1_2",
 ] }
 log = { version = "0.4.21", default-features = false }
 num = { version = "0.4.3", default-features = false }


### PR DESCRIPTION
This PR updates the Cosmos packages by transitioning dependencies to workspace-level management, standardizing package metadata, introducing a nostd crate to improve support for no_std environments, and adjusting the cosmwasm-std version.