### PR TITLE
feat: Add transaction cache to prevent duplicate transaction processing

### DIFF
--- a/frame/solana/src/lib.rs
+++ b/frame/solana/src/lib.rs
@@ -259,10 +259,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn transaction_count)]
-	pub type TransactionCount<T> = StorageValue<_, u64, ValueQuery>;
-
-	#[pallet::storage]
 	#[pallet::getter(fn transaction_cache)]
 	pub type TransactionCache<T: Config> = StorageMap<
 		_,
@@ -329,11 +325,6 @@ pub mod pallet {
 			let blockhash = <frame_system::Pallet<T>>::block_hash(to_remove);
 			<BlockhashQueue<T>>::remove(blockhash);
 			<TransactionCache<T>>::remove(blockhash);
-
-			let count = frame_system::Pallet::<T>::extrinsic_count() as u64;
-			TransactionCount::<T>::mutate(|total_count| {
-				*total_count = total_count.saturating_add(count)
-			});
 		}
 	}
 
@@ -406,9 +397,9 @@ pub mod pallet {
 
 			let bank = <Bank<T>>::new(<Slot<T>>::get());
 
-			if bank.load_execute_and_commit_sanitized_transaction(sanitized_tx.clone()).is_ok() {
+			if bank.load_execute_and_commit_sanitized_transaction(&sanitized_tx).is_ok() {
 				Self::update_transaction_cache(&sanitized_tx)?;
-			};
+			}
 
 			Ok(().into())
 		}
@@ -462,10 +453,6 @@ pub mod pallet {
 			} else {
 				None
 			}
-		}
-
-		pub fn get_transaction_count() -> u64 {
-			TransactionCount::<T>::get()
 		}
 
 		pub fn simulate_transaction(

--- a/frame/solana/src/lib.rs
+++ b/frame/solana/src/lib.rs
@@ -228,7 +228,7 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Failed to reallocate account data of this length
 		InvalidRealloc,
-		///
+		/// Transaction cache limit reached.
 		CacheLimitReached,
 	}
 
@@ -262,6 +262,7 @@ pub mod pallet {
 	pub type TransactionCount<T> = StorageValue<_, u64, ValueQuery>;
 
 	#[pallet::storage]
+	#[pallet::getter(fn transaction_cache)]
 	pub type TransactionCache<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
@@ -418,7 +419,7 @@ pub mod pallet {
 		) -> TransactionValidity {
 			let mut builder = ValidTransactionBuilder::default();
 
-			Self::check_transaction(&transaction)?;
+			Self::check_transaction(transaction)?;
 
 			builder.build()
 		}
@@ -428,7 +429,7 @@ pub mod pallet {
 			_fee_payer: Pubkey,
 			transaction: &Transaction,
 		) -> Result<(), TransactionValidityError> {
-			Self::check_transaction(&transaction)?;
+			Self::check_transaction(transaction)?;
 
 			Ok(())
 		}

--- a/frame/solana/src/lib.rs
+++ b/frame/solana/src/lib.rs
@@ -181,7 +181,7 @@ pub mod pallet {
 		type ScanResultsLimitBytes: Get<Option<u32>>;
 
 		#[pallet::constant]
-		type MaxTransactionCacheLimit: Get<u32>;
+		type TransactionCacheLimit: Get<u32>;
 	}
 
 	pub mod config_preludes {
@@ -214,7 +214,7 @@ pub mod pallet {
 			/// Maximum scan result size in bytes.
 			type ScanResultsLimitBytes = ScanResultsLimitBytes;
 
-			type MaxTransactionCacheLimit = ConstU32<10000>;
+			type TransactionCacheLimit = ConstU32<10000>;
 		}
 	}
 
@@ -266,7 +266,7 @@ pub mod pallet {
 		_,
 		Twox64Concat,
 		T::Hash,
-		BoundedBTreeSet<T::Hash, T::MaxTransactionCacheLimit>,
+		BoundedBTreeSet<T::Hash, T::TransactionCacheLimit>,
 		ValueQuery,
 	>;
 
@@ -556,7 +556,7 @@ pub mod pallet {
 
 			ensure!(
 				<TransactionCache<T>>::get(blockhash).len() <
-					T::MaxTransactionCacheLimit::get() as usize,
+					T::TransactionCacheLimit::get() as usize,
 				Error::<T>::CacheLimitReached
 			);
 			<TransactionCache<T>>::mutate(blockhash, |cache| {

--- a/frame/solana/src/runtime/bank.rs
+++ b/frame/solana/src/runtime/bank.rs
@@ -206,9 +206,9 @@ impl<T: Config> Bank<T> {
 
 	pub fn load_execute_and_commit_sanitized_transaction(
 		&self,
-		sanitized_tx: SanitizedTransaction,
+		sanitized_tx: &SanitizedTransaction,
 	) -> Result<()> {
-		let check_result = self.check_transaction(&sanitized_tx, T::BlockhashQueueMaxAge::get());
+		let check_result = self.check_transaction(sanitized_tx, T::BlockhashQueueMaxAge::get());
 
 		let blockhash = T::HashConversion::convert_back(<frame_system::Pallet<T>>::parent_hash());
 		// FIXME: Update lamports_per_signature.
@@ -240,14 +240,14 @@ impl<T: Config> Bank<T> {
 		let mut sanitized_output =
 			self.transaction_processor.load_and_execute_sanitized_transaction(
 				self,
-				&sanitized_tx,
+				sanitized_tx,
 				check_result,
 				&processing_environment,
 				&processing_config,
 			);
 
 		self.commit_transaction(
-			&sanitized_tx,
+			sanitized_tx,
 			&mut sanitized_output.loaded_transaction,
 			sanitized_output.execution_result.clone(),
 			blockhash,

--- a/frame/solana/src/tests.rs
+++ b/frame/solana/src/tests.rs
@@ -82,7 +82,7 @@ fn process_transaction(bank: &Bank<Test>, tx: Transaction) -> Result<()> {
 	)
 	.expect("Transaction must be sanitized");
 
-	bank.load_execute_and_commit_sanitized_transaction(sanitized_tx)
+	bank.load_execute_and_commit_sanitized_transaction(&sanitized_tx)
 }
 
 fn mock_deploy_program(program_id: &Pubkey, data: Vec<u8>) {


### PR DESCRIPTION
This PR introduces a transaction cache mechanism to prevent duplicate transaction processing. The cache ensures that each transaction is processed only once by checking for its existence before processing.