### PR TITLE
fix: Use Vec from nostd for no_std environment

### DIFF
--- a/frame/solana/runtime-api/src/account.rs
+++ b/frame/solana/runtime-api/src/account.rs
@@ -17,7 +17,7 @@
 
 use crate::{error::Error, SolanaRuntimeCall};
 use frame_support::traits::Get;
-use nostd::marker::PhantomData;
+use nostd::{marker::PhantomData, prelude::*};
 use pallet_solana::Pubkey;
 use solana_inline_spl::token::GenericTokenAccount;
 use solana_rpc_client_api::filter::RpcFilterType;
@@ -101,7 +101,7 @@ impl<T> ProgramAccounts<T> {
 	}
 
 	fn calc_scan_result_size(account: &Account) -> usize {
-		account.data().len() + std::mem::size_of::<Account>() + std::mem::size_of::<Pubkey>()
+		account.data().len() + core::mem::size_of::<Account>() + core::mem::size_of::<Pubkey>()
 	}
 }
 

--- a/frame/solana/runtime-api/src/lib.rs
+++ b/frame/solana/runtime-api/src/lib.rs
@@ -24,7 +24,7 @@ pub mod fee;
 pub mod transaction;
 
 use error::Error;
-use nostd::{string::String, vec::Vec};
+use nostd::prelude::*;
 use sp_api::decl_runtime_apis;
 
 decl_runtime_apis! {

--- a/frame/solana/runtime-api/src/transaction.rs
+++ b/frame/solana/runtime-api/src/transaction.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use crate::{error::Error, SolanaRuntimeCall};
-use nostd::marker::PhantomData;
+use nostd::{marker::PhantomData, prelude::*};
 use pallet_solana::{runtime::bank::TransactionSimulationResult, Pubkey};
 use solana_sdk::{
 	feature_set::FeatureSet,

--- a/frame/solana/src/lib.rs
+++ b/frame/solana/src/lib.rs
@@ -108,7 +108,7 @@ pub mod pallet {
 		},
 	};
 	use frame_system::{pallet_prelude::*, CheckWeight};
-	use nostd::sync::Arc;
+	use nostd::{prelude::*, sync::Arc};
 	use np_runtime::traits::LossyInto;
 	use parity_scale_codec::Codec;
 	use solana_sdk::{

--- a/vendor/solana/rpc-client-api/src/filter.rs
+++ b/vendor/solana/rpc-client-api/src/filter.rs
@@ -1,6 +1,6 @@
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
-    nostd::borrow::Cow,
+    nostd::{borrow::Cow, prelude::*},
     serde::{Deserialize, Serialize},
     solana_inline_spl::{token::GenericTokenAccount, token_2022::Account},
     solana_sdk::account::{AccountSharedData, ReadableAccount},


### PR DESCRIPTION
This PR adds Vec from the nostd package to pallet-solana for use in a no_std environment.