### PR TITLE
build(deps): Update polkadot-sdk to use crates.io versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,31 +122,28 @@ test-case = "3.3.1"
 thiserror = { version = "2.0", default-features = false }
 
 # substrate
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+frame-support = { version = "38.0.0", default-features = false }
+frame-system = { version = "38.0.0", default-features = false }
+pallet-assets = { version = "40.0.0", default-features = false }
+pallet-balances = { version = "39.0.0", default-features = false }
+pallet-sudo = { version = "38.0.0", default-features = false }
+pallet-timestamp = { version = "37.0.0", default-features = false }
+pallet-transaction-payment = { version = "38.0.0", default-features = false }
+sp-core = { version = "34.0.0", default-features = false }
+sp-io = { version = "38.0.0", default-features = false }
+sp-keyring = { version = "39.0.0", default-features = false }
+sp-runtime = { version = "39.0.1", default-features = false }
 
 # frontier
-fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-fp-self-contained = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-blake2 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+fp-evm = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+fp-self-contained = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+pallet-evm-precompile-blake2 = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
+precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "crates.io/stable2409", default-features = false }
 
 # noir
 cosmos-rpc = { path = "frame/cosmos/rpc", default-features = false }

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -13,6 +13,4 @@ np-runtime = { workspace = true }
 
 [features]
 default = ["std"]
-std = [
-	"np-runtime/std",
-]
+std = ["np-runtime/std"]

--- a/frame/babel/Cargo.toml
+++ b/frame/babel/Cargo.toml
@@ -12,28 +12,19 @@ publish = false
 workspace = true
 
 [dependencies]
+# common
 bech32 = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
-cosmos-sdk-proto = { workspace = true, optional = true }
-cosmwasm-std = { workspace = true, default-features = false, optional = true }
-cosmwasm-vm = { workspace = true, default-features = false, optional = true }
-cosmwasm-vm-wasmi = { workspace = true, default-features = false, optional = true }
+hex-literal = { workspace = true }
+num_enum = { workspace = true, optional = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
+serde-json-wasm = { workspace = true, optional = true }
+
+# ethereum
 ethereum = { workspace = true, optional = true }
 fp-evm = { workspace = true, optional = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-hex-literal = { workspace = true }
-np-babel = { workspace = true, default-features = false }
-np-multimap = { workspace = true, default-features = false }
-num_enum = { workspace = true, optional = true }
-pallet-assets = { workspace = true, optional = true }
-pallet-balances = { workspace = true }
-pallet-cosmos = { workspace = true, default-features = false, optional = true }
-pallet-cosmos-types = { workspace = true, default-features = false, optional = true }
-pallet-cosmos-x-auth-signing = { workspace = true, default-features = false, optional = true }
-pallet-cosmos-x-bank = { workspace = true, default-features = false, optional = true }
-pallet-cosmos-x-wasm = { workspace = true, default-features = false, optional = true }
-pallet-cosmwasm = { workspace = true, default-features = false, optional = true }
 pallet-ethereum = { workspace = true, optional = true }
 pallet-evm = { workspace = true, optional = true }
 pallet-evm-precompileset-assets-erc20 = { workspace = true, optional = true }
@@ -42,16 +33,36 @@ pallet-evm-precompile-blake2 = { workspace = true, optional = true }
 pallet-evm-precompile-bn128 = { workspace = true, optional = true }
 pallet-evm-precompile-modexp = { workspace = true, optional = true }
 pallet-evm-precompile-simple = { workspace = true, optional = true }
-pallet-solana = { workspace = true, optional = true }
-parity-scale-codec = { workspace = true }
 precompile-utils = { workspace = true, optional = true }
-scale-info = { workspace = true }
-serde = { workspace = true, optional = true }
-serde-json-wasm = { workspace = true, optional = true }
+
+# cosmos
+cosmos-sdk-proto = { workspace = true, optional = true }
+cosmwasm-std = { workspace = true, default-features = false, optional = true }
+cosmwasm-vm = { workspace = true, default-features = false, optional = true }
+cosmwasm-vm-wasmi = { workspace = true, default-features = false, optional = true }
+pallet-cosmos = { workspace = true, default-features = false, optional = true }
+pallet-cosmos-types = { workspace = true, default-features = false, optional = true }
+pallet-cosmos-x-auth-signing = { workspace = true, default-features = false, optional = true }
+pallet-cosmos-x-bank = { workspace = true, default-features = false, optional = true }
+pallet-cosmos-x-wasm = { workspace = true, default-features = false, optional = true }
+pallet-cosmwasm = { workspace = true, default-features = false, optional = true }
+
+# solana
+pallet-solana = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true }
+
+# substrate
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-assets = { workspace = true, optional = true }
+pallet-balances = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
+
+# noir
+np-babel = { workspace = true, default-features = false }
+np-multimap = { workspace = true, default-features = false }
 
 [dev-dependencies]
 const-hex = { workspace = true, default-features = true }
@@ -149,7 +160,7 @@ nostr = ["np-babel/nostr"]
 solana = [
 	"bincode",
 	"np-babel/solana",
-	"pallet-solana", 
+	"pallet-solana",
 	"solana-sdk",
 ]
 pallet = [


### PR DESCRIPTION
This PR bumps Polkadot SDK to `stable2409-3` published on `crates.io`.