### PR TITLE
refactor: Streamline Cosmos-to-Polkadot type conversion and vice versa

### DIFF
--- a/frame/babel/src/cosmos/address.rs
+++ b/frame/babel/src/cosmos/address.rs
@@ -22,7 +22,9 @@ use bech32::{Bech32, Hrp};
 use core::marker::PhantomData;
 use np_babel::cosmos::{traits::ChainInfo, Address as CosmosAddress};
 use np_multimap::traits::UniqueMultimap;
-use pallet_cosmos_types::address::acc_address_from_bech32;
+use pallet_cosmos_types::address::{
+	acc_address_from_bech32, AUTH_ADDRESS_LEN, CONTRACT_ADDRESS_LEN,
+};
 use pallet_cosmwasm::types::AccountIdOf;
 use sp_core::{H160, H256};
 use sp_runtime::traits::{AccountIdConversion, Convert, MaybeConvert, TryConvert};
@@ -75,11 +77,11 @@ where
 {
 	fn maybe_convert(address: Vec<u8>) -> Option<AccountIdOf<T>> {
 		match address.len() {
-			20 => {
+			AUTH_ADDRESS_LEN => {
 				let address = CosmosAddress::from(H160::from_slice(&address));
 				T::AddressMap::find_key(VarAddress::Cosmos(address))
 			},
-			32 => Some(H256::from_slice(&address).into()),
+			CONTRACT_ADDRESS_LEN => Some(H256::from_slice(&address).into()),
 			_ => None,
 		}
 	}

--- a/frame/babel/src/cosmos/address.rs
+++ b/frame/babel/src/cosmos/address.rs
@@ -25,7 +25,7 @@ use np_multimap::traits::UniqueMultimap;
 use pallet_cosmos_types::address::acc_address_from_bech32;
 use pallet_cosmwasm::types::AccountIdOf;
 use sp_core::{H160, H256};
-use sp_runtime::traits::{AccountIdConversion, Convert};
+use sp_runtime::traits::{AccountIdConversion, Convert, MaybeConvert, TryConvert};
 
 pub struct AddressMapping<T>(PhantomData<T>);
 impl<T> pallet_cosmos::AddressMapping<T::AccountId> for AddressMapping<T>
@@ -46,41 +46,41 @@ where
 {
 	fn convert(account: AccountIdOf<T>) -> String {
 		let addresses = T::AddressMap::get(&account);
-		let address: Option<&CosmosAddress> = addresses.iter().find_map(|address| match address {
-			VarAddress::Cosmos(address) => Some(address),
-			_ => None,
-		});
-		let address_raw = match address {
-			Some(address) => address.as_ref(),
-			None => account.as_ref(),
-		};
+		let address_raw = addresses
+			.iter()
+			.find_map(|address| match address {
+				VarAddress::Cosmos(addr) => Some(addr.as_ref()),
+				_ => None,
+			})
+			.unwrap_or_else(|| account.as_ref());
+
 		let hrp = Hrp::parse(T::ChainInfo::bech32_prefix()).unwrap();
 		bech32::encode::<Bech32>(hrp, address_raw).unwrap()
 	}
 }
 
-impl<T> Convert<String, Result<AccountIdOf<T>, ()>> for AccountToAddr<T>
+impl<T> TryConvert<String, AccountIdOf<T>> for AccountToAddr<T>
 where
 	T: pallet_cosmwasm::Config + unify_account::Config<AccountId = AccountIdOf<T>>,
 {
-	fn convert(address: String) -> Result<AccountIdOf<T>, ()> {
-		let (_hrp, address_raw) = acc_address_from_bech32(&address).map_err(|_| ())?;
-		Self::convert(address_raw)
+	fn try_convert(address: String) -> Result<AccountIdOf<T>, String> {
+		let (_hrp, data) = acc_address_from_bech32(&address).map_err(|_| address.clone())?;
+		Self::maybe_convert(data).ok_or(address)
 	}
 }
 
-impl<T> Convert<Vec<u8>, Result<AccountIdOf<T>, ()>> for AccountToAddr<T>
+impl<T> MaybeConvert<Vec<u8>, AccountIdOf<T>> for AccountToAddr<T>
 where
 	T: pallet_cosmwasm::Config + unify_account::Config<AccountId = AccountIdOf<T>>,
 {
-	fn convert(address: Vec<u8>) -> Result<AccountIdOf<T>, ()> {
+	fn maybe_convert(address: Vec<u8>) -> Option<AccountIdOf<T>> {
 		match address.len() {
 			20 => {
 				let address = CosmosAddress::from(H160::from_slice(&address));
-				T::AddressMap::find_key(VarAddress::Cosmos(address)).ok_or(())
+				T::AddressMap::find_key(VarAddress::Cosmos(address))
 			},
-			32 => Ok(H256::from_slice(&address).into()),
-			_ => Err(()),
+			32 => Some(H256::from_slice(&address).into()),
+			_ => None,
 		}
 	}
 }

--- a/frame/babel/src/cosmos/precompile.rs
+++ b/frame/babel/src/cosmos/precompile.rs
@@ -26,7 +26,7 @@ use cosmwasm_vm::{
 use cosmwasm_vm_wasmi::OwnedWasmiVM;
 use frame_support::{
 	dispatch::{GetDispatchInfo, PostDispatchInfo},
-	PalletId,
+	ensure, PalletId,
 };
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::address::{acc_address_from_bech32, AUTH_ADDRESS_LEN};
@@ -95,9 +95,8 @@ where
 					let sender = vm.0.data().cosmwasm_message_info.sender.clone().into_string();
 					let (_hrp, address_raw) = acc_address_from_bech32(&sender)
 						.map_err(|_| CosmwasmVMError::AccountConvert)?;
-					if address_raw.len() != AUTH_ADDRESS_LEN {
-						return Err(CosmwasmVMError::AccountConvert);
-					}
+					ensure!(address_raw.len() == AUTH_ADDRESS_LEN, CosmwasmVMError::AccountConvert);
+
 					let origin = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 					call.dispatch(Some(origin).into())

--- a/frame/babel/src/cosmos/precompile.rs
+++ b/frame/babel/src/cosmos/precompile.rs
@@ -29,7 +29,7 @@ use frame_support::{
 	PalletId,
 };
 use pallet_cosmos::AddressMapping;
-use pallet_cosmos_types::address::acc_address_from_bech32;
+use pallet_cosmos_types::address::{acc_address_from_bech32, AUTH_ADDRESS_LEN};
 use pallet_cosmwasm::{
 	pallet_hook::PalletHook,
 	runtimes::vm::{CosmwasmVM, CosmwasmVMError},
@@ -95,7 +95,7 @@ where
 					let sender = vm.0.data().cosmwasm_message_info.sender.clone().into_string();
 					let (_hrp, address_raw) = acc_address_from_bech32(&sender)
 						.map_err(|_| CosmwasmVMError::AccountConvert)?;
-					if address_raw.len() != 20 {
+					if address_raw.len() != AUTH_ADDRESS_LEN {
 						return Err(CosmwasmVMError::AccountConvert);
 					}
 					let origin = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));

--- a/frame/babel/src/lib.rs
+++ b/frame/babel/src/lib.rs
@@ -62,7 +62,7 @@ pub mod pallet {
 		types::{AssetIdOf, DenomOf},
 		AddressMapping as _,
 	};
-	use pallet_cosmos_types::address::acc_address_from_bech32;
+	use pallet_cosmos_types::address::{acc_address_from_bech32, AUTH_ADDRESS_LEN};
 	use pallet_cosmos_x_auth_signing::sign_verifiable_tx::traits::SigVerifiableTx;
 	use pallet_evm::{AddressMapping as _, FrameSystemAccountProvider};
 	use solana_sdk::transaction::VersionedTransaction;
@@ -228,7 +228,7 @@ pub mod pallet {
 			let (_hrp, address_raw) =
 				acc_address_from_bech32(signer).map_err(|_| Error::<T>::InvalidTransaction)?;
 			ensure!(
-				address_raw.len() == 20 && address.to_vec() == address_raw,
+				address_raw.len() == AUTH_ADDRESS_LEN && address.to_vec() == address_raw,
 				Error::<T>::InvalidTransaction
 			);
 

--- a/frame/babel/src/lib.rs
+++ b/frame/babel/src/lib.rs
@@ -196,14 +196,14 @@ pub mod pallet {
 			use cosmos_sdk_proto::traits::Message;
 			use cosmos_sdk_proto::cosmos::tx::v1beta1::Tx;
 			use pallet_cosmos::weights::WeightInfo;
-			use sp_runtime::traits::Convert;
+			use sp_runtime::traits::ConvertBack;
 
 			Tx::decode(&mut &tx_bytes[..])
 				.ok()
 				.and_then(|tx| tx.auth_info)
 				.and_then(|auth_info| auth_info.fee)
 				.map_or(<T as pallet_cosmos::Config>::WeightInfo::base_weight(), |fee| {
-					<T as pallet_cosmos::Config>::WeightToGas::convert(fee.gas_limit)
+					<T as pallet_cosmos::Config>::WeightToGas::convert_back(fee.gas_limit)
 				})
 		})]
 		pub fn cosmos_transact(

--- a/frame/babel/src/mock.rs
+++ b/frame/babel/src/mock.rs
@@ -69,7 +69,7 @@ use pallet_solana::Pubkey;
 use solana_sdk::hash::Hash;
 use sp_core::{ConstU128, Pair, H256};
 use sp_runtime::{
-	traits::{Convert, ConvertBack, IdentityLookup, TryConvert},
+	traits::{Convert, ConvertBack, IdentityLookup, TryConvert, TryConvertBack},
 	BoundedVec, BuildStorage,
 };
 
@@ -192,17 +192,6 @@ impl context::traits::MinGasPrices for MinGasPrices {
 }
 
 pub struct AssetToDenom;
-impl TryConvert<String, AssetId> for AssetToDenom {
-	fn try_convert(denom: String) -> Result<AssetId, String> {
-		if denom == NativeDenom::get() {
-			Ok(NativeAssetId::get())
-		} else {
-			let denom_raw: BoundedVec<u8, MaxDenomLimit> =
-				denom.as_bytes().to_vec().try_into().map_err(|_| denom.clone())?;
-			<Test as frame_babel::Config>::AssetMap::find_key(denom_raw).ok_or(denom.clone())
-		}
-	}
-}
 impl TryConvert<AssetId, String> for AssetToDenom {
 	fn try_convert(asset_id: AssetId) -> Result<String, AssetId> {
 		if asset_id == NativeAssetId::get() {
@@ -210,6 +199,17 @@ impl TryConvert<AssetId, String> for AssetToDenom {
 		} else {
 			let denom = <Test as frame_babel::Config>::AssetMap::get(asset_id).ok_or(asset_id)?;
 			String::from_utf8(denom.into()).map_err(|_| asset_id)
+		}
+	}
+}
+impl TryConvertBack<AssetId, String> for AssetToDenom {
+	fn try_convert_back(denom: String) -> Result<AssetId, String> {
+		if denom == NativeDenom::get() {
+			Ok(NativeAssetId::get())
+		} else {
+			let denom_raw: BoundedVec<u8, MaxDenomLimit> =
+				denom.as_bytes().to_vec().try_into().map_err(|_| denom.clone())?;
+			<Test as frame_babel::Config>::AssetMap::find_key(denom_raw).ok_or(denom.clone())
 		}
 	}
 }

--- a/frame/cosmos/src/lib.rs
+++ b/frame/cosmos/src/lib.rs
@@ -31,7 +31,7 @@ use frame_support::{
 use frame_system::{pallet_prelude::*, CheckWeight};
 use nostd::prelude::*;
 use pallet_cosmos_types::{
-	address::acc_address_from_bech32,
+	address::{acc_address_from_bech32, AUTH_ADDRESS_LEN},
 	context::traits::Context,
 	errors::{CosmosError, RootError},
 	events::traits::EventManager,
@@ -85,7 +85,7 @@ where
 					T::SigVerifiableTx::fee_payer(&tx).map_err(|_| InvalidTransaction::Call)?;
 				let (_hrp, address_raw) = acc_address_from_bech32(&fee_payer)
 					.map_err(|_| InvalidTransaction::BadSigner)?;
-				ensure!(address_raw.len() == 20, InvalidTransaction::BadSigner);
+				ensure!(address_raw.len() == AUTH_ADDRESS_LEN, InvalidTransaction::BadSigner);
 
 				Ok(H160::from_slice(&address_raw))
 			};

--- a/frame/cosmos/types/src/address.rs
+++ b/frame/cosmos/types/src/address.rs
@@ -26,6 +26,9 @@ pub enum Error {
 	DecodeError(DecodeError),
 }
 
+pub const AUTH_ADDRESS_LEN: usize = 20;
+pub const CONTRACT_ADDRESS_LEN: usize = 32;
+
 pub fn acc_address_from_bech32(address: &str) -> Result<(String, Vec<u8>), Error> {
 	bech32::decode(address)
 		.map(|(hrp, data)| (hrp.to_string(), data))

--- a/frame/cosmos/types/src/address.rs
+++ b/frame/cosmos/types/src/address.rs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bech32::DecodeError;
 use nostd::{
 	string::{String, ToString},
 	vec::Vec,
@@ -22,7 +23,7 @@ use nostd::{
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Error {
-	DecodeError(bech32::DecodeError),
+	DecodeError(DecodeError),
 }
 
 pub fn acc_address_from_bech32(address: &str) -> Result<(String, Vec<u8>), Error> {

--- a/frame/cosmos/x/auth/src/fee.rs
+++ b/frame/cosmos/x/auth/src/fee.rs
@@ -41,7 +41,7 @@ use pallet_cosmos_types::{
 use pallet_cosmos_x_auth_signing::sign_verifiable_tx::traits::SigVerifiableTx;
 use sp_core::{Get, H160};
 use sp_runtime::{
-	traits::{TryConvert, Zero},
+	traits::{TryConvertBack, Zero},
 	SaturatedConversion,
 };
 
@@ -126,7 +126,7 @@ where
 
 				// TODO: Resolve imbalance
 			} else {
-				let asset_id = T::AssetToDenom::try_convert(amt.denom.clone())
+				let asset_id = T::AssetToDenom::try_convert_back(amt.denom.clone())
 					.map_err(|_| RootError::InsufficientFunds)?;
 				let _imbalance = T::Assets::withdraw(
 					asset_id,

--- a/frame/cosmos/x/auth/src/fee.rs
+++ b/frame/cosmos/x/auth/src/fee.rs
@@ -28,7 +28,7 @@ use frame_support::{
 use nostd::vec;
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
-	address::acc_address_from_bech32,
+	address::{acc_address_from_bech32, AUTH_ADDRESS_LEN},
 	coin::traits::Coins,
 	context::traits::MinGasPrices,
 	errors::{CosmosError, RootError},
@@ -88,7 +88,7 @@ where
 
 		let (_hrp, address_raw) =
 			acc_address_from_bech32(&fee_payer).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let deduct_fees_from = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 		if !fee.amount.is_empty() {

--- a/frame/cosmos/x/auth/src/sigverify.rs
+++ b/frame/cosmos/x/auth/src/sigverify.rs
@@ -29,7 +29,7 @@ use nostd::vec::Vec;
 use np_cosmos::traits::ChainInfo;
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
-	address::acc_address_from_bech32,
+	address::{acc_address_from_bech32, AUTH_ADDRESS_LEN},
 	any_match,
 	errors::{CosmosError, RootError},
 	handler::AnteDecorator,
@@ -63,7 +63,7 @@ where
 
 			let (_hrp, signer_addr_raw) =
 				acc_address_from_bech32(signer).map_err(|_| RootError::InvalidAddress)?;
-			ensure!(signer_addr_raw.len() == 20, RootError::InvalidAddress);
+			ensure!(signer_addr_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 			let who = T::AddressMapping::into_account_id(H160::from_slice(&signer_addr_raw));
 
 			let sequence = frame_system::Pallet::<T>::account_nonce(&who).saturated_into();
@@ -115,7 +115,7 @@ where
 
 					let (_hrp, signer_addr_raw) =
 						acc_address_from_bech32(&signer_data.address).map_err(|_| RootError::InvalidAddress)?;
-					ensure!(signer_addr_raw.len() == 20, RootError::InvalidAddress);
+					ensure!(signer_addr_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 
 					ensure!(H160::from_slice(&signer_addr_raw) == address, RootError::Unauthorized);
 
@@ -204,7 +204,7 @@ where
 		for signer in signers.iter() {
 			let (_hrp, address_raw) =
 				acc_address_from_bech32(signer).map_err(|_| RootError::InvalidAddress)?;
-			ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+			ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 
 			let account = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 			frame_system::pallet::Pallet::<T>::inc_account_nonce(account);

--- a/frame/cosmos/x/bank/src/lib.rs
+++ b/frame/cosmos/x/bank/src/lib.rs
@@ -46,7 +46,7 @@ use pallet_cosmos_types::{
 use pallet_cosmos_x_bank_types::events::{ATTRIBUTE_KEY_RECIPIENT, EVENT_TYPE_TRANSFER};
 use sp_core::{Get, H160};
 use sp_runtime::{
-	traits::{TryConvert, Zero},
+	traits::{TryConvertBack, Zero},
 	SaturatedConversion,
 };
 
@@ -101,7 +101,7 @@ where
 				if frame_system::Account::<T>::get(&to_account).nonce.is_zero() {
 					return Err(RootError::UnknownAddress.into());
 				}
-				let asset_id = T::AssetToDenom::try_convert(amt.denom.clone())
+				let asset_id = T::AssetToDenom::try_convert_back(amt.denom.clone())
 					.map_err(|_| RootError::InvalidCoins)?;
 				T::Assets::transfer(
 					asset_id,

--- a/frame/cosmos/x/bank/src/lib.rs
+++ b/frame/cosmos/x/bank/src/lib.rs
@@ -32,7 +32,7 @@ use gas::GasInfo;
 use nostd::{marker::PhantomData, vec};
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
-	address::acc_address_from_bech32,
+	address::{acc_address_from_bech32, AUTH_ADDRESS_LEN},
 	coin::traits::Coins,
 	context,
 	errors::{CosmosError, RootError},
@@ -69,12 +69,12 @@ where
 
 		let (_hrp, from_address_raw) =
 			acc_address_from_bech32(&from_address).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(from_address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(from_address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let from_account = T::AddressMapping::into_account_id(H160::from_slice(&from_address_raw));
 
 		let (_hrp, to_address_raw) =
 			acc_address_from_bech32(&to_address).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(to_address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(to_address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let to_account = T::AddressMapping::into_account_id(H160::from_slice(&to_address_raw));
 
 		for amt in amount.iter() {

--- a/frame/cosmos/x/wasm/src/msgs.rs
+++ b/frame/cosmos/x/wasm/src/msgs.rs
@@ -32,7 +32,7 @@ use libflate::gzip::Decoder;
 use nostd::io::Read;
 use pallet_cosmos::AddressMapping;
 use pallet_cosmos_types::{
-	address::acc_address_from_bech32,
+	address::{acc_address_from_bech32, AUTH_ADDRESS_LEN},
 	context,
 	errors::{CosmosError, RootError},
 	events::{traits::EventManager, CosmosEvent, EventAttribute},
@@ -79,7 +79,7 @@ where
 		ensure!(!sender.is_empty(), WasmError::Empty);
 		let (_hrp, address_raw) =
 			acc_address_from_bech32(&sender).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let who = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 		ctx.gas_meter()
@@ -136,7 +136,7 @@ where
 		ensure!(!sender.is_empty(), WasmError::Empty);
 		let (_hrp, address_raw) =
 			acc_address_from_bech32(&sender).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let who = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 		let gas = ctx.gas_meter().gas_remaining();
@@ -217,7 +217,7 @@ where
 		ensure!(!sender.is_empty(), WasmError::Empty);
 		let (_hrp, address_raw) =
 			acc_address_from_bech32(&sender).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let who = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 		let gas = ctx.gas_meter().gas_remaining();
@@ -292,7 +292,7 @@ where
 		ensure!(!sender.is_empty(), WasmError::Empty);
 		let (_hrp, address_raw) =
 			acc_address_from_bech32(&sender).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let who = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 		let gas = ctx.gas_meter().gas_remaining();
@@ -355,7 +355,7 @@ where
 		ensure!(!sender.is_empty(), WasmError::Empty);
 		let (_hrp, address_raw) =
 			acc_address_from_bech32(&sender).map_err(|_| RootError::InvalidAddress)?;
-		ensure!(address_raw.len() == 20, RootError::InvalidAddress);
+		ensure!(address_raw.len() == AUTH_ADDRESS_LEN, RootError::InvalidAddress);
 		let who = T::AddressMapping::into_account_id(H160::from_slice(&address_raw));
 
 		let gas = ctx.gas_meter().gas_remaining();

--- a/vendor/composable/cosmwasm/src/lib.rs
+++ b/vendor/composable/cosmwasm/src/lib.rs
@@ -133,7 +133,7 @@ pub mod pallet {
 		transactional, PalletId, Twox64Concat,
 	};
 	use frame_system::{ensure_signed, pallet_prelude::OriginFor};
-	use sp_runtime::traits::{Convert, MaybeDisplay, TryConvert};
+	use sp_runtime::traits::{Convert, MaybeConvert, MaybeDisplay, TryConvert, TryConvertBack};
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -290,8 +290,8 @@ pub mod pallet {
 
 		/// A way to convert from our native account to cosmwasm `Addr`.
 		type AccountToAddr: Convert<AccountIdOf<Self>, String>
-			+ Convert<String, Result<AccountIdOf<Self>, ()>>
-			+ Convert<Vec<u8>, Result<AccountIdOf<Self>, ()>>;
+			+ TryConvert<String, AccountIdOf<Self>>
+			+ MaybeConvert<Vec<u8>, AccountIdOf<Self>>;
 
 		/// Type of an account balance.
 		type Balance: Balance + Into<u128>;
@@ -302,7 +302,7 @@ pub mod pallet {
 		type AssetId: AssetId + Ord;
 
 		/// A way to convert from our native currency to cosmwasm `Denom`.
-		type AssetToDenom: TryConvert<Self::AssetId, String> + TryConvert<String, AssetIdOf<Self>>;
+		type AssetToDenom: TryConvertBack<Self::AssetId, String>;
 
 		/// Interface used to pay when uploading code.
 		type NativeAsset: ReservableCurrency<AccountIdOf<Self>, Balance = BalanceOf<Self>>
@@ -1033,7 +1033,6 @@ impl<T: Config> Pallet<T> {
 					CosmwasmAccount::new(contract),
 					new_admin.map(CosmwasmAccount::new),
 				)
-				.map_err(Into::into)
 			},
 		)
 	}


### PR DESCRIPTION
This PR refactors the Cosmos-to-Polkadot type conversion. It defines constants for Cosmos user and contract address lengths and replaces the length check with the ensure! macro for Cosmos address validation.