### PR TITLE
build(deps): Bump Polkadot SDK to stable2412

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ eager = "0.1.0"
 either = { version = "1.8", default-features = false }
 enum-iterator = "1.5.0"
 env_logger = "0.9"
-ethereum = { version = "0.15.0", default-features = false }
+ethereum = { git = "https://github.com/rust-ethereum/ethereum", rev = "3be0d8fd4c2ad1ba216b69ef65b9382612efc8ba", default-features = false }
 futures = "0.3"
 futures-timer = "3.0"
 getrandom = { version = "0.2", default-features = false }
@@ -160,39 +160,40 @@ wasmi-validation = { version = "0.5.0", default-features = false }
 wat = "1.0"
 
 # substrate
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412" }
+sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2412", default-features = false }
 
 # frontier
-fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-fp-self-contained = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-blake2 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+fp-self-contained = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+pallet-ethereum = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+pallet-evm-precompile-blake2 = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
+precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2412", default-features = false }
 
 # noir
 cosmos-rpc = { path = "frame/cosmos/rpc", default-features = false }

--- a/frame/babel/Cargo.toml
+++ b/frame/babel/Cargo.toml
@@ -52,6 +52,7 @@ solana-sdk = { workspace = true, optional = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
+sp-weights = { workspace = true }
 
 [dev-dependencies]
 const-hex = { workspace = true, default-features = true }
@@ -112,6 +113,7 @@ std = [
 	"solana-sdk?/std",
 	"sp-core/std",
 	"sp-runtime/std",
+	"sp-weights/std",
 ]
 cosmos = [
 	"bech32",
@@ -149,7 +151,7 @@ nostr = ["np-babel/nostr"]
 solana = [
 	"bincode",
 	"np-babel/solana",
-	"pallet-solana", 
+	"pallet-solana",
 	"solana-sdk",
 ]
 pallet = [

--- a/frame/babel/src/cosmos/precompile.rs
+++ b/frame/babel/src/cosmos/precompile.rs
@@ -87,7 +87,7 @@ where
 				if let Ok(ExecuteMsg::Dispatch { input }) = serde_json_wasm::from_slice(message) {
 					let call = T::RuntimeCall::decode_with_depth_limit(DECODE_LIMIT, &mut &*input)
 						.map_err(|_| CosmwasmVMError::ExecuteDeserialize)?;
-					let weight = call.get_dispatch_info().weight;
+					let weight = call.get_dispatch_info().total_weight();
 					vm.0.data_mut()
 						.charge_raw(T::WeightToGas::convert(weight))
 						.map_err(|_| CosmwasmVMError::OutOfGas)?;

--- a/frame/babel/src/ethereum/precompile.rs
+++ b/frame/babel/src/ethereum/precompile.rs
@@ -133,8 +133,8 @@ where
 		let info = call.get_dispatch_info();
 
 		if let Some(gas) = target_gas {
-			let valid_weight =
-				info.weight.ref_time() <= T::GasWeightMapping::gas_to_weight(gas, false).ref_time();
+			let valid_weight = info.total_weight().ref_time() <=
+				T::GasWeightMapping::gas_to_weight(gas, false).ref_time();
 			if !valid_weight {
 				return Err(PrecompileFailure::Error { exit_status: ExitError::OutOfGas });
 			}
@@ -147,21 +147,27 @@ where
 		}
 
 		handle.record_external_cost(
-			Some(info.weight.ref_time()),
-			Some(info.weight.proof_size()),
+			Some(info.total_weight().ref_time()),
+			Some(info.total_weight().proof_size()),
 			None,
 		)?;
 
 		match call.dispatch(Some(origin).into()) {
 			Ok(post_info) => {
 				if post_info.pays_fee(&info) == Pays::Yes {
-					let actual_weight = post_info.actual_weight.unwrap_or(info.weight);
+					let actual_weight = post_info.actual_weight.unwrap_or(info.total_weight());
 					let cost = T::GasWeightMapping::weight_to_gas(actual_weight);
 					handle.record_cost(cost)?;
 
 					handle.refund_external_cost(
-						Some(info.weight.ref_time().saturating_sub(actual_weight.ref_time())),
-						Some(info.weight.proof_size().saturating_sub(actual_weight.proof_size())),
+						Some(
+							info.total_weight().ref_time().saturating_sub(actual_weight.ref_time()),
+						),
+						Some(
+							info.total_weight()
+								.proof_size()
+								.saturating_sub(actual_weight.proof_size()),
+						),
 					);
 				}
 

--- a/frame/cosmos/src/lib.rs
+++ b/frame/cosmos/src/lib.rs
@@ -120,7 +120,10 @@ where
 		len: usize,
 	) -> Option<Result<(), TransactionValidityError>> {
 		if let Call::transact { tx_bytes } = self {
-			if let Err(e) = CheckWeight::<T>::do_pre_dispatch(dispatch_info, len) {
+			if let Err(e) =
+				CheckWeight::<T>::do_validate(dispatch_info, len).and_then(|(_, next_len)| {
+					CheckWeight::<T>::do_prepare(dispatch_info, len, next_len)
+				}) {
 				return Some(Err(e));
 			}
 

--- a/frame/solana/src/lib.rs
+++ b/frame/solana/src/lib.rs
@@ -643,7 +643,10 @@ pub mod pallet {
 			len: usize,
 		) -> Option<Result<(), TransactionValidityError>> {
 			if let Call::transact { transaction } = self {
-				if let Err(e) = CheckWeight::<T>::do_pre_dispatch(dispatch_info, len) {
+				if let Err(e) =
+					CheckWeight::<T>::do_validate(dispatch_info, len).and_then(|(_, next_len)| {
+						CheckWeight::<T>::do_prepare(dispatch_info, len, next_len)
+					}) {
 					return Some(Err(e));
 				}
 

--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -145,7 +145,7 @@ mod tests {
 	}
 	impl UpperBounded for CustomNumeric {
 		fn max_value() -> Self {
-			CustomNumeric(u8::max_value())
+			CustomNumeric(u8::MAX)
 		}
 	}
 	impl core::ops::Mul for CustomNumeric {

--- a/primitives/consensus/pow/src/lib.rs
+++ b/primitives/consensus/pow/src/lib.rs
@@ -54,7 +54,7 @@ where
 	Hash: AsRef<[u8]>,
 	Difficulty: Into<U256>,
 {
-	let hash = U256::from(hash.as_ref());
+	let hash = U256::from_big_endian(hash.as_ref());
 	let (_, overflowed) = hash.overflowing_mul(difficulty.into());
 
 	!overflowed
@@ -69,7 +69,7 @@ where
 	let is_zero = hash.as_ref().iter().all(|&x| x == 0);
 
 	if !is_zero {
-		Difficulty::saturated_from(U256::max_value() / U256::from(hash.as_ref()))
+		Difficulty::saturated_from(U256::max_value() / U256::from_big_endian(hash.as_ref()))
 	} else {
 		Difficulty::max_value()
 	}

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true, optional = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
+sp-weights = { workspace = true }
 
 [features]
 default = ["std"]
@@ -33,6 +34,7 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-weights/std",
 ]
 serde = [
 	"dep:serde",

--- a/primitives/runtime/src/generic/mod.rs
+++ b/primitives/runtime/src/generic/mod.rs
@@ -24,27 +24,31 @@ use frame_support::{
 	traits::ExtrinsicCall,
 };
 use scale_info::TypeInfo;
-use sp_runtime::traits::SignedExtension;
+use sp_runtime::traits::{Dispatchable, TransactionExtension};
 
-impl<Address, Call, Signature, Extra> GetDispatchInfo
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> GetDispatchInfo
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
-	Call: GetDispatchInfo,
-	Extra: SignedExtension,
+	Call: GetDispatchInfo + Dispatchable,
+	Extension: TransactionExtension<Call>,
 {
 	fn get_dispatch_info(&self) -> DispatchInfo {
-		self.function.get_dispatch_info()
+		let mut info = self.function.get_dispatch_info();
+		info.extension_weight = self.extension_weight();
+		info
 	}
 }
 
-impl<Address, Call, Signature, Extra> ExtrinsicCall
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> ExtrinsicCall
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: TypeInfo,
 	Call: TypeInfo,
 	Signature: TypeInfo,
-	Extra: SignedExtension + TypeInfo,
+	Extension: TypeInfo,
 {
+	type Call = Call;
+
 	fn call(&self) -> &Self::Call {
 		&self.function
 	}

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -863,13 +863,9 @@ mod tests {
 	#[test]
 	fn signed_check_should_work() {
 		let sig_payload = {
-      DummyExtension.implicit().unwrap();
-      SignedPayload::from_raw(
-      			FakeDispatchable::from(vec![0u8; 0]),
-      			DummyExtension,
-      			(),
-      		)
-  };
+			DummyExtension.implicit().unwrap();
+			SignedPayload::from_raw(FakeDispatchable::from(vec![0u8; 0]), DummyExtension, ())
+		};
 		let ux = Ex::new_signed(
 			vec![0u8; 0].into(),
 			TEST_ACCOUNT,
@@ -951,10 +947,8 @@ mod tests {
 		let signed = TEST_ACCOUNT;
 		let extension = DummyExtension;
 		extension.implicit().unwrap();
-		let signature = TestSig(
-			TEST_ACCOUNT,
-			blake2_256(&(&call, DummyExtension, &()).encode()[..]).to_vec(),
-		);
+		let signature =
+			TestSig(TEST_ACCOUNT, blake2_256(&(&call, DummyExtension, &()).encode()[..]).to_vec());
 
 		let old_ux =
 			UncheckedExtrinsicV4::<TestAccountId, TestCall, TestSig, DummyExtension>::new_signed(

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -26,24 +26,178 @@ use core::fmt;
 use scale_info::{build::Fields, meta_type, Path, StaticTypeInfo, Type, TypeInfo, TypeParameter};
 use sp_io::hashing::blake2_256;
 use sp_runtime::{
-	generic::CheckedExtrinsic,
+	generic::{CheckedExtrinsic, ExtrinsicFormat},
 	traits::{
-		self, Checkable, Extrinsic, ExtrinsicMetadata, IdentifyAccount, MaybeDisplay, Member,
-		/* SignaturePayload, */ SignedExtension,
+		self, transaction_extension::TransactionExtension, Checkable, Dispatchable, ExtrinsicLike,
+		ExtrinsicMetadata, IdentifyAccount, MaybeDisplay, Member, /* SignaturePayload, */
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic,
 };
+use sp_weights::Weight;
+
+/// Type to represent the version of the [Extension](TransactionExtension) used in this extrinsic.
+pub type ExtensionVersion = u8;
+/// Type to represent the extrinsic format version which defines an [UncheckedExtrinsic].
+pub type ExtrinsicVersion = u8;
 
 /// Current version of the [`UncheckedExtrinsic`] encoded format.
 ///
 /// This version needs to be bumped if the encoded representation changes.
 /// It ensures that if the representation is changed and the format is not known,
 /// the decoding fails.
-const EXTRINSIC_FORMAT_VERSION: u8 = 4;
+pub const EXTRINSIC_FORMAT_VERSION: ExtrinsicVersion = 5;
+/// Legacy version of the [`UncheckedExtrinsic`] encoded format.
+///
+/// This version was used in the signed/unsigned transaction model and is still supported for
+/// compatibility reasons. It will be deprecated in favor of v5 extrinsics and an inherent/general
+/// transaction model.
+pub const LEGACY_EXTRINSIC_FORMAT_VERSION: ExtrinsicVersion = 4;
+/// Current version of the [Extension](TransactionExtension) used in this
+/// [extrinsic](UncheckedExtrinsic).
+///
+/// This version needs to be bumped if there are breaking changes to the extension used in the
+/// [UncheckedExtrinsic] implementation.
+const EXTENSION_VERSION: ExtensionVersion = 0;
 
-/// The `SignaturePayload` of `UncheckedExtrinsic`.
-type UncheckedSignaturePayload<Address, Signature, Extra> = (Address, Signature, Extra);
+// The `SignaturePayload` of `UncheckedExtrinsic`.
+//pub type UncheckedSignaturePayload<Address, Signature, Extension> = (Address, Signature,
+// Extension);
+//
+//impl<Address: TypeInfo, Signature: TypeInfo, Extension: TypeInfo> SignaturePayload
+//	for UncheckedSignaturePayload<Address, Signature, Extension>
+//{
+//	type SignatureAddress = Address;
+//	type Signature = Signature;
+//	type SignatureExtra = Extension;
+//}
+
+/// A "header" for extrinsics leading up to the call itself. Determines the type of extrinsic and
+/// holds any necessary specialized data.
+#[derive(Eq, PartialEq, Clone)]
+pub enum Preamble<Address, Signature, Extension> {
+	/// An extrinsic without a signature or any extension. This means it's either an inherent or
+	/// an old-school "Unsigned" (we don't use that terminology any more since it's confusable with
+	/// the general transaction which is without a signature but does have an extension).
+	///
+	/// NOTE: In the future, once we remove `ValidateUnsigned`, this will only serve Inherent
+	/// extrinsics and thus can be renamed to `Inherent`.
+	Bare(ExtrinsicVersion),
+	/// An old-school transaction extrinsic which includes a signature of some hard-coded crypto.
+	/// Available only on extrinsic version 4.
+	Signed(Address, Signature, Extension),
+	/// A new-school transaction extrinsic which does not include a signature by default. The
+	/// origin authorization, through signatures or other means, is performed by the transaction
+	/// extension in this extrinsic. Available starting with extrinsic version 5.
+	General(ExtensionVersion, Extension),
+}
+
+const VERSION_MASK: u8 = 0b0011_1111;
+const TYPE_MASK: u8 = 0b1100_0000;
+const BARE_EXTRINSIC: u8 = 0b0000_0000;
+const SIGNED_EXTRINSIC: u8 = 0b1000_0000;
+const GENERAL_EXTRINSIC: u8 = 0b0100_0000;
+
+impl<Address, Signature, Extension> Decode for Preamble<Address, Signature, Extension>
+where
+	Address: Decode,
+	Signature: Decode,
+	Extension: Decode,
+{
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		let version_and_type = input.read_byte()?;
+
+		let version = version_and_type & VERSION_MASK;
+		let xt_type = version_and_type & TYPE_MASK;
+
+		let preamble = match (version, xt_type) {
+			(
+				extrinsic_version @ LEGACY_EXTRINSIC_FORMAT_VERSION..=EXTRINSIC_FORMAT_VERSION,
+				BARE_EXTRINSIC,
+			) => Self::Bare(extrinsic_version),
+			(LEGACY_EXTRINSIC_FORMAT_VERSION, SIGNED_EXTRINSIC) => {
+				let address = Address::decode(input)?;
+				let signature = Signature::decode(input)?;
+				let ext = Extension::decode(input)?;
+				Self::Signed(address, signature, ext)
+			},
+			(EXTRINSIC_FORMAT_VERSION, GENERAL_EXTRINSIC) => {
+				let ext_version = ExtensionVersion::decode(input)?;
+				let ext = Extension::decode(input)?;
+				Self::General(ext_version, ext)
+			},
+			(_, _) => return Err("Invalid transaction version".into()),
+		};
+
+		Ok(preamble)
+	}
+}
+
+impl<Address, Signature, Extension> Encode for Preamble<Address, Signature, Extension>
+where
+	Address: Encode,
+	Signature: Encode,
+	Extension: Encode,
+{
+	fn size_hint(&self) -> usize {
+		match &self {
+			Preamble::Bare(_) => EXTRINSIC_FORMAT_VERSION.size_hint(),
+			Preamble::Signed(address, signature, ext) => LEGACY_EXTRINSIC_FORMAT_VERSION
+				.size_hint()
+				.saturating_add(address.size_hint())
+				.saturating_add(signature.size_hint())
+				.saturating_add(ext.size_hint()),
+			Preamble::General(ext_version, ext) => EXTRINSIC_FORMAT_VERSION
+				.size_hint()
+				.saturating_add(ext_version.size_hint())
+				.saturating_add(ext.size_hint()),
+		}
+	}
+
+	fn encode_to<T: codec::Output + ?Sized>(&self, dest: &mut T) {
+		match &self {
+			Preamble::Bare(extrinsic_version) => {
+				(extrinsic_version | BARE_EXTRINSIC).encode_to(dest);
+			},
+			Preamble::Signed(address, signature, ext) => {
+				(LEGACY_EXTRINSIC_FORMAT_VERSION | SIGNED_EXTRINSIC).encode_to(dest);
+				address.encode_to(dest);
+				signature.encode_to(dest);
+				ext.encode_to(dest);
+			},
+			Preamble::General(ext_version, ext) => {
+				(EXTRINSIC_FORMAT_VERSION | GENERAL_EXTRINSIC).encode_to(dest);
+				ext_version.encode_to(dest);
+				ext.encode_to(dest);
+			},
+		}
+	}
+}
+
+impl<Address, Signature, Extension> Preamble<Address, Signature, Extension> {
+	/// Returns `Some` if this is a signed extrinsic, together with the relevant inner fields.
+	pub fn to_signed(self) -> Option<(Address, Signature, Extension)> {
+		match self {
+			Self::Signed(a, s, e) => Some((a, s, e)),
+			_ => None,
+		}
+	}
+}
+
+impl<Address, Signature, Extension> fmt::Debug for Preamble<Address, Signature, Extension>
+where
+	Address: fmt::Debug,
+	Extension: fmt::Debug,
+{
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Self::Bare(_) => write!(f, "Bare"),
+			Self::Signed(address, _, tx_ext) => write!(f, "Signed({:?}, {:?})", address, tx_ext),
+			Self::General(ext_version, tx_ext) =>
+				write!(f, "General({:?}, {:?})", ext_version, tx_ext),
+		}
+	}
+}
 
 /// An extrinsic right from the external world. This is unchecked and so can contain a signature.
 ///
@@ -68,43 +222,28 @@ type UncheckedSignaturePayload<Address, Signature, Extra> = (Address, Signature,
 /// This can be checked using [`Checkable`], yielding a [`CheckedExtrinsic`], which is the
 /// counterpart of this type after its signature (and other non-negotiable validity checks) have
 /// passed.
-#[derive(PartialEq, Eq, Clone)]
-pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>
-where
-	Extra: SignedExtension,
-{
-	/// The signature, address, number of extrinsics have come before from the same signer and an
-	/// era describing the longevity of this transaction, if this is a signed extrinsic.
-	///
-	/// `None` if it is unsigned or an inherent.
-	pub signature: Option<UncheckedSignaturePayload<Address, Signature, Extra>>,
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct UncheckedExtrinsic<Address, Call, Signature, Extension> {
+	/// Information regarding the type of extrinsic this is (inherent or transaction) as well as
+	/// associated extension (`Extension`) data if it's a transaction and a possible signature.
+	pub preamble: Preamble<Address, Signature, Extension>,
 	/// The function that should be called.
 	pub function: Call,
 }
-
-/*
-impl<Address: TypeInfo, Signature: TypeInfo, Extra: TypeInfo> SignaturePayload
-	for UncheckedSignaturePayload<Address, Signature, Extra>
-{
-	type SignatureAddress = Address;
-	type Signature = Signature;
-	type SignatureExtra = Extra;
-}
-*/
 
 /// Manual [`TypeInfo`] implementation because of custom encoding. The data is a valid encoded
 /// `Vec<u8>`, but requires some logic to extract the signature and payload.
 ///
 /// See [`UncheckedExtrinsic::encode`] and [`UncheckedExtrinsic::decode`].
-impl<Address, Call, Signature, Extra> TypeInfo
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> TypeInfo
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: StaticTypeInfo,
 	Call: StaticTypeInfo,
 	Signature: StaticTypeInfo,
-	Extra: SignedExtension + StaticTypeInfo,
+	Extension: StaticTypeInfo,
 {
-	type Identity = UncheckedExtrinsic<Address, Call, Signature, Extra>;
+	type Identity = UncheckedExtrinsic<Address, Call, Signature, Extension>;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -116,7 +255,7 @@ where
 				TypeParameter::new("Address", Some(meta_type::<Address>())),
 				TypeParameter::new("Call", Some(meta_type::<Call>())),
 				TypeParameter::new("Signature", Some(meta_type::<Signature>())),
-				TypeParameter::new("Extra", Some(meta_type::<Extra>())),
+				TypeParameter::new("Extra", Some(meta_type::<Extension>())),
 			])
 			.docs(&["UncheckedExtrinsic raw bytes, requires custom decoding routine"])
 			// Because of the custom encoding, we can only accurately describe the encoding as an
@@ -126,67 +265,106 @@ where
 	}
 }
 
-impl<Address, Call, Signature, Extra: SignedExtension>
-	UncheckedExtrinsic<Address, Call, Signature, Extra>
-{
-	/// New instance of a signed extrinsic aka "transaction".
-	pub fn new_signed(function: Call, signed: Address, signature: Signature, extra: Extra) -> Self {
-		Self { signature: Some((signed, signature, extra)), function }
+impl<Address, Call, Signature, Extension> UncheckedExtrinsic<Address, Call, Signature, Extension> {
+	/// New instance of a bare (ne unsigned) extrinsic. This could be used for an inherent or an
+	/// old-school "unsigned transaction" (which are new being deprecated in favour of general
+	/// transactions).
+	#[deprecated = "Use new_bare instead"]
+	pub fn new_unsigned(function: Call) -> Self {
+		Self::new_bare(function)
 	}
 
-	/// New instance of an unsigned extrinsic aka "inherent".
-	pub fn new_unsigned(function: Call) -> Self {
-		Self { signature: None, function }
+	/// Returns `true` if this extrinsic instance is an inherent, `false`` otherwise.
+	pub fn is_inherent(&self) -> bool {
+		matches!(self.preamble, Preamble::Bare(_))
+	}
+
+	/// Returns `true` if this extrinsic instance is an old-school signed transaction, `false`
+	/// otherwise.
+	pub fn is_signed(&self) -> bool {
+		matches!(self.preamble, Preamble::Signed(..))
+	}
+
+	/// Create an `UncheckedExtrinsic` from a `Preamble` and the actual `Call`.
+	pub fn from_parts(function: Call, preamble: Preamble<Address, Signature, Extension>) -> Self {
+		Self { preamble, function }
+	}
+
+	/// New instance of a bare (ne unsigned) extrinsic.
+	pub fn new_bare(function: Call) -> Self {
+		Self { preamble: Preamble::Bare(EXTRINSIC_FORMAT_VERSION), function }
+	}
+
+	/// New instance of a bare (ne unsigned) extrinsic on extrinsic format version 4.
+	pub fn new_bare_legacy(function: Call) -> Self {
+		Self { preamble: Preamble::Bare(LEGACY_EXTRINSIC_FORMAT_VERSION), function }
+	}
+
+	/// New instance of an old-school signed transaction on extrinsic format version 4.
+	pub fn new_signed(
+		function: Call,
+		signed: Address,
+		signature: Signature,
+		tx_ext: Extension,
+	) -> Self {
+		Self { preamble: Preamble::Signed(signed, signature, tx_ext), function }
+	}
+
+	/// New instance of an new-school unsigned transaction.
+	pub fn new_transaction(function: Call, tx_ext: Extension) -> Self {
+		Self { preamble: Preamble::General(EXTENSION_VERSION, tx_ext), function }
 	}
 }
 
-impl<Address: TypeInfo, Call: TypeInfo, Signature: TypeInfo, Extra: SignedExtension + TypeInfo>
-	Extrinsic for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address: TypeInfo, Call: TypeInfo, Signature: TypeInfo, Extension: TypeInfo> ExtrinsicLike
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 {
-	type Call = Call;
-
-	type SignaturePayload = UncheckedSignaturePayload<Address, Signature, Extra>;
+	fn is_bare(&self) -> bool {
+		matches!(self.preamble, Preamble::Bare(_))
+	}
 
 	fn is_signed(&self) -> Option<bool> {
-		Some(self.signature.is_some())
-	}
-
-	fn new(function: Call, signed_data: Option<Self::SignaturePayload>) -> Option<Self> {
-		Some(if let Some((address, signature, extra)) = signed_data {
-			Self::new_signed(function, address, signature, extra)
-		} else {
-			Self::new_unsigned(function)
-		})
+		Some(matches!(self.preamble, Preamble::Signed(..)))
 	}
 }
 
-impl<LookupSource, AccountId, Call, Signature, Extra, Lookup> Checkable<Lookup>
-	for UncheckedExtrinsic<LookupSource, Call, Signature, Extra>
+// TODO: Migrate existing extension pipelines to support current `Signed` transactions as `General`
+// transactions by adding an extension to validate signatures, as they are currently validated in
+// the `Checkable` implementation for `Signed` transactions.
+
+impl<LookupSource, AccountId, Call, Signature, Extension, Lookup> Checkable<Lookup>
+	for UncheckedExtrinsic<LookupSource, Call, Signature, Extension>
 where
 	LookupSource: Member + MaybeDisplay,
-	Call: Encode + Member,
-	Signature: Member + VerifyMut,
+	Call: Encode + Member + Dispatchable,
+	Signature: Member + traits::Verify + VerifyMut,
+	<Signature as traits::Verify>::Signer: IdentifyAccount<AccountId = AccountId>,
 	<Signature as VerifyMut>::Signer: IdentifyAccount<AccountId = AccountId>,
-	Extra: SignedExtension<AccountId = AccountId>,
+	Extension: Encode + TransactionExtension<Call>,
 	AccountId: Member + MaybeDisplay,
 	Lookup: traits::Lookup<Source = LookupSource, Target = AccountId>,
 {
-	type Checked = CheckedExtrinsic<AccountId, Call, Extra>;
+	type Checked = CheckedExtrinsic<AccountId, Call, Extension>;
 
 	fn check(self, lookup: &Lookup) -> Result<Self::Checked, TransactionValidityError> {
-		Ok(match self.signature {
-			Some((signed, signature, extra)) => {
+		Ok(match self.preamble {
+			Preamble::Signed(signed, signature, tx_ext) => {
 				let mut signed = lookup.lookup(signed)?;
-				let raw_payload = SignedPayload::new(self.function, extra)?;
+				// The `Implicit` is "implicitly" included in the payload.
+				let raw_payload = SignedPayload::new(self.function, tx_ext)?;
 				if !raw_payload.using_encoded(|payload| signature.verify_mut(payload, &mut signed))
 				{
 					return Err(InvalidTransaction::BadProof.into())
 				}
-
-				let (function, extra, _) = raw_payload.deconstruct();
-				CheckedExtrinsic { signed: Some((signed, extra)), function }
+				let (function, tx_ext, _) = raw_payload.deconstruct();
+				CheckedExtrinsic { format: ExtrinsicFormat::Signed(signed, tx_ext), function }
 			},
-			None => CheckedExtrinsic { signed: None, function: self.function },
+			Preamble::General(extension_version, tx_ext) => CheckedExtrinsic {
+				format: ExtrinsicFormat::General(extension_version, tx_ext),
+				function: self.function,
+			},
+			Preamble::Bare(_) =>
+				CheckedExtrinsic { format: ExtrinsicFormat::Bare, function: self.function },
 		})
 	}
 
@@ -195,91 +373,51 @@ where
 		self,
 		lookup: &Lookup,
 	) -> Result<Self::Checked, TransactionValidityError> {
-		Ok(match self.signature {
-			Some((signed, _, extra)) => {
+		Ok(match self.preamble {
+			Preamble::Signed(signed, _, tx_ext) => {
 				let signed = lookup.lookup(signed)?;
-				let raw_payload = SignedPayload::new(self.function, extra)?;
-				let (function, extra, _) = raw_payload.deconstruct();
-				CheckedExtrinsic { signed: Some((signed, extra)), function }
+				CheckedExtrinsic {
+					format: ExtrinsicFormat::Signed(signed, tx_ext),
+					function: self.function,
+				}
 			},
-			None => CheckedExtrinsic { signed: None, function: self.function },
+			Preamble::General(extension_version, tx_ext) => CheckedExtrinsic {
+				format: ExtrinsicFormat::General(extension_version, tx_ext),
+				function: self.function,
+			},
+			Preamble::Bare(_) =>
+				CheckedExtrinsic { format: ExtrinsicFormat::Bare, function: self.function },
 		})
 	}
 }
 
-impl<Address, Call, Signature, Extra> ExtrinsicMetadata
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
-where
-	Extra: SignedExtension,
+impl<Address, Call: Dispatchable, Signature, Extension: TransactionExtension<Call>>
+	ExtrinsicMetadata for UncheckedExtrinsic<Address, Call, Signature, Extension>
 {
-	const VERSION: u8 = EXTRINSIC_FORMAT_VERSION;
-	type SignedExtensions = Extra;
+	const VERSIONS: &'static [u8] = &[LEGACY_EXTRINSIC_FORMAT_VERSION, EXTRINSIC_FORMAT_VERSION];
+	type TransactionExtensions = Extension;
 }
 
-/// A payload that has been signed for an unchecked extrinsics.
-///
-/// Note that the payload that we sign to produce unchecked extrinsic signature
-/// is going to be different than the `SignaturePayload` - so the thing the extrinsic
-/// actually contains.
-pub struct SignedPayload<Call, Extra: SignedExtension>((Call, Extra, Extra::AdditionalSigned));
-
-impl<Call, Extra> SignedPayload<Call, Extra>
-where
-	Call: Encode,
-	Extra: SignedExtension,
+impl<Address, Call: Dispatchable, Signature, Extension: TransactionExtension<Call>>
+	UncheckedExtrinsic<Address, Call, Signature, Extension>
 {
-	/// Create new `SignedPayload`.
-	///
-	/// This function may fail if `additional_signed` of `Extra` is not available.
-	pub fn new(call: Call, extra: Extra) -> Result<Self, TransactionValidityError> {
-		let additional_signed = extra.additional_signed()?;
-		let raw_payload = (call, extra, additional_signed);
-		Ok(Self(raw_payload))
-	}
-
-	/// Create new `SignedPayload` from raw components.
-	pub fn from_raw(call: Call, extra: Extra, additional_signed: Extra::AdditionalSigned) -> Self {
-		Self((call, extra, additional_signed))
-	}
-
-	/// Deconstruct the payload into it's components.
-	pub fn deconstruct(self) -> (Call, Extra, Extra::AdditionalSigned) {
-		self.0
+	/// Returns the weight of the extension of this transaction, if present. If the transaction
+	/// doesn't use any extension, the weight returned is equal to zero.
+	pub fn extension_weight(&self) -> Weight {
+		match &self.preamble {
+			Preamble::Bare(_) => Weight::zero(),
+			Preamble::Signed(_, _, ext) | Preamble::General(_, ext) => ext.weight(&self.function),
+		}
 	}
 }
 
-impl<Call, Extra> Encode for SignedPayload<Call, Extra>
-where
-	Call: Encode,
-	Extra: SignedExtension,
-{
-	/// Get an encoded version of this payload.
-	///
-	/// Payloads longer than 256 bytes are going to be `blake2_256`-hashed.
-	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-		self.0.using_encoded(|payload| {
-			if payload.len() > 256 {
-				f(&blake2_256(payload)[..])
-			} else {
-				f(payload)
-			}
-		})
-	}
-}
-
-impl<Call, Extra> EncodeLike for SignedPayload<Call, Extra>
-where
-	Call: Encode,
-	Extra: SignedExtension,
-{
-}
-
-impl<Address, Call, Signature, Extra> Decode for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> Decode
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: Decode,
 	Signature: Decode,
 	Call: Decode,
-	Extra: SignedExtension,
+	Extension: Decode,
 {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		// This is a little more complicated than usual since the binary format must be compatible
@@ -288,15 +426,7 @@ where
 		let expected_length: Compact<u32> = Decode::decode(input)?;
 		let before_length = input.remaining_len()?;
 
-		let version = input.read_byte()?;
-
-		let is_signed = version & 0b1000_0000 != 0;
-		let version = version & 0b0111_1111;
-		if version != EXTRINSIC_FORMAT_VERSION {
-			return Err("Invalid transaction version".into())
-		}
-
-		let signature = is_signed.then(|| Decode::decode(input)).transpose()?;
+		let preamble = Decode::decode(input)?;
 		let function = Decode::decode(input)?;
 
 		if let Some((before_length, after_length)) =
@@ -309,31 +439,20 @@ where
 			}
 		}
 
-		Ok(Self { signature, function })
+		Ok(Self { preamble, function })
 	}
 }
 
 //#[docify::export(unchecked_extrinsic_encode_impl)]
-impl<Address, Call, Signature, Extra> Encode for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> Encode
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
-	Address: Encode,
-	Signature: Encode,
+	Preamble<Address, Signature, Extension>: Encode,
 	Call: Encode,
-	Extra: SignedExtension,
+	Extension: Encode,
 {
 	fn encode(&self) -> Vec<u8> {
-		let mut tmp = Vec::with_capacity(core::mem::size_of::<Self>());
-
-		// 1 byte version id.
-		match self.signature.as_ref() {
-			Some(s) => {
-				tmp.push(EXTRINSIC_FORMAT_VERSION | 0b1000_0000);
-				s.encode_to(&mut tmp);
-			},
-			None => {
-				tmp.push(EXTRINSIC_FORMAT_VERSION & 0b0111_1111);
-			},
-		}
+		let mut tmp = self.preamble.encode();
 		self.function.encode_to(&mut tmp);
 
 		let compact_len = codec::Compact::<u32>(tmp.len() as u32);
@@ -348,19 +467,19 @@ where
 	}
 }
 
-impl<Address, Call, Signature, Extra> EncodeLike
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> EncodeLike
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: Encode,
 	Signature: Encode,
-	Call: Encode,
-	Extra: SignedExtension,
+	Call: Encode + Dispatchable,
+	Extension: TransactionExtension<Call>,
 {
 }
 
 #[cfg(feature = "serde")]
-impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> serde::Serialize
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address: Encode, Signature: Encode, Call: Encode, Extension: Encode> serde::Serialize
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error>
 	where
@@ -371,45 +490,86 @@ impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> s
 }
 
 #[cfg(feature = "serde")]
-impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtension>
-	serde::Deserialize<'a> for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extension: Decode> serde::Deserialize<'a>
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'a>,
 	{
 		let r = sp_core::bytes::deserialize(de)?;
-		Decode::decode(&mut &r[..])
+		Self::decode(&mut &r[..])
 			.map_err(|e| serde::de::Error::custom(format!("Decode error: {}", e)))
 	}
 }
 
-impl<Address, Call, Signature, Extra> fmt::Debug
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+/// A payload that has been signed for an unchecked extrinsics.
+///
+/// Note that the payload that we sign to produce unchecked extrinsic signature
+/// is going to be different than the `SignaturePayload` - so the thing the extrinsic
+/// actually contains.
+pub struct SignedPayload<Call: Dispatchable, Extension: TransactionExtension<Call>>(
+	(Call, Extension, Extension::Implicit),
+);
+
+impl<Call, Extension> SignedPayload<Call, Extension>
 where
-	Address: fmt::Debug,
-	Call: fmt::Debug,
-	Extra: SignedExtension,
+	Call: Encode + Dispatchable,
+	Extension: TransactionExtension<Call>,
 {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(
-			f,
-			"UncheckedExtrinsic({:?}, {:?})",
-			self.signature.as_ref().map(|x| (&x.0, &x.2)),
-			self.function,
-		)
+	/// Create new `SignedPayload` for extrinsic format version 4.
+	///
+	/// This function may fail if `implicit` of `Extension` is not available.
+	pub fn new(call: Call, tx_ext: Extension) -> Result<Self, TransactionValidityError> {
+		let implicit = Extension::implicit(&tx_ext)?;
+		let raw_payload = (call, tx_ext, implicit);
+		Ok(Self(raw_payload))
+	}
+
+	/// Create new `SignedPayload` from raw components.
+	pub fn from_raw(call: Call, tx_ext: Extension, implicit: Extension::Implicit) -> Self {
+		Self((call, tx_ext, implicit))
+	}
+
+	/// Deconstruct the payload into it's components.
+	pub fn deconstruct(self) -> (Call, Extension, Extension::Implicit) {
+		self.0
 	}
 }
 
-impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Signature, Extra>>
-	for OpaqueExtrinsic
+impl<Call, Extension> Encode for SignedPayload<Call, Extension>
+where
+	Call: Encode + Dispatchable,
+	Extension: TransactionExtension<Call>,
+{
+	/// Get an encoded version of this `blake2_256`-hashed payload.
+	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+		self.0.using_encoded(|payload| {
+			if payload.len() > 256 {
+				f(&blake2_256(payload)[..])
+			} else {
+				f(payload)
+			}
+		})
+	}
+}
+
+impl<Call, Extension> EncodeLike for SignedPayload<Call, Extension>
+where
+	Call: Encode + Dispatchable,
+	Extension: TransactionExtension<Call>,
+{
+}
+
+impl<Address, Call, Signature, Extension>
+	From<UncheckedExtrinsic<Address, Call, Signature, Extension>> for OpaqueExtrinsic
 where
 	Address: Encode,
 	Signature: Encode,
 	Call: Encode,
-	Extra: SignedExtension,
+	Extension: Encode,
 {
-	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
+	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extension>) -> Self {
 		Self::from_bytes(extrinsic.encode().as_slice()).expect(
 			"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
 				raw Vec<u8> encoding; qed",
@@ -418,18 +578,168 @@ where
 }
 
 #[cfg(test)]
+mod legacy {
+	use codec::{Compact, Decode, Encode, EncodeLike, Error, Input};
+	use scale_info::{
+		build::Fields, meta_type, Path, StaticTypeInfo, Type, TypeInfo, TypeParameter,
+	};
+
+	pub type UncheckedSignaturePayloadV4<Address, Signature, Extra> = (Address, Signature, Extra);
+
+	#[derive(PartialEq, Eq, Clone, Debug)]
+	pub struct UncheckedExtrinsicV4<Address, Call, Signature, Extra> {
+		pub signature: Option<UncheckedSignaturePayloadV4<Address, Signature, Extra>>,
+		pub function: Call,
+	}
+
+	impl<Address, Call, Signature, Extra> TypeInfo
+		for UncheckedExtrinsicV4<Address, Call, Signature, Extra>
+	where
+		Address: StaticTypeInfo,
+		Call: StaticTypeInfo,
+		Signature: StaticTypeInfo,
+		Extra: StaticTypeInfo,
+	{
+		type Identity = UncheckedExtrinsicV4<Address, Call, Signature, Extra>;
+
+		fn type_info() -> Type {
+			Type::builder()
+				.path(Path::new("UncheckedExtrinsic", module_path!()))
+				// Include the type parameter types, even though they are not used directly in any
+				// of the described fields. These type definitions can be used by downstream
+				// consumers to help construct the custom decoding from the opaque bytes (see
+				// below).
+				.type_params(vec![
+					TypeParameter::new("Address", Some(meta_type::<Address>())),
+					TypeParameter::new("Call", Some(meta_type::<Call>())),
+					TypeParameter::new("Signature", Some(meta_type::<Signature>())),
+					TypeParameter::new("Extra", Some(meta_type::<Extra>())),
+				])
+				.docs(&["OldUncheckedExtrinsic raw bytes, requires custom decoding routine"])
+				// Because of the custom encoding, we can only accurately describe the encoding as
+				// an opaque `Vec<u8>`. Downstream consumers will need to manually implement the
+				// codec to encode/decode the `signature` and `function` fields.
+				.composite(Fields::unnamed().field(|f| f.ty::<Vec<u8>>()))
+		}
+	}
+
+	impl<Address, Call, Signature, Extra> UncheckedExtrinsicV4<Address, Call, Signature, Extra> {
+		pub fn new_signed(
+			function: Call,
+			signed: Address,
+			signature: Signature,
+			extra: Extra,
+		) -> Self {
+			Self { signature: Some((signed, signature, extra)), function }
+		}
+
+		pub fn new_unsigned(function: Call) -> Self {
+			Self { signature: None, function }
+		}
+	}
+
+	impl<Address, Call, Signature, Extra> Decode
+		for UncheckedExtrinsicV4<Address, Call, Signature, Extra>
+	where
+		Address: Decode,
+		Signature: Decode,
+		Call: Decode,
+		Extra: Decode,
+	{
+		fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+			// This is a little more complicated than usual since the binary format must be
+			// compatible with SCALE's generic `Vec<u8>` type. Basically this just means accepting
+			// that there will be a prefix of vector length.
+			let expected_length: Compact<u32> = Decode::decode(input)?;
+			let before_length = input.remaining_len()?;
+
+			let version = input.read_byte()?;
+
+			let is_signed = version & 0b1000_0000 != 0;
+			let version = version & 0b0111_1111;
+			if version != 4u8 {
+				return Err("Invalid transaction version".into())
+			}
+
+			let signature = is_signed.then(|| Decode::decode(input)).transpose()?;
+			let function = Decode::decode(input)?;
+
+			if let Some((before_length, after_length)) =
+				input.remaining_len()?.and_then(|a| before_length.map(|b| (b, a)))
+			{
+				let length = before_length.saturating_sub(after_length);
+
+				if length != expected_length.0 as usize {
+					return Err("Invalid length prefix".into())
+				}
+			}
+
+			Ok(Self { signature, function })
+		}
+	}
+
+	//#[docify::export(unchecked_extrinsic_encode_impl)]
+	impl<Address, Call, Signature, Extra> Encode
+		for UncheckedExtrinsicV4<Address, Call, Signature, Extra>
+	where
+		Address: Encode,
+		Signature: Encode,
+		Call: Encode,
+		Extra: Encode,
+	{
+		fn encode(&self) -> Vec<u8> {
+			let mut tmp = Vec::with_capacity(core::mem::size_of::<Self>());
+
+			// 1 byte version id.
+			match self.signature.as_ref() {
+				Some(s) => {
+					tmp.push(4u8 | 0b1000_0000);
+					s.encode_to(&mut tmp);
+				},
+				None => {
+					tmp.push(4u8 & 0b0111_1111);
+				},
+			}
+			self.function.encode_to(&mut tmp);
+
+			let compact_len = codec::Compact::<u32>(tmp.len() as u32);
+
+			// Allocate the output buffer with the correct length
+			let mut output = Vec::with_capacity(compact_len.size_hint() + tmp.len());
+
+			compact_len.encode_to(&mut output);
+			output.extend(tmp);
+
+			output
+		}
+	}
+
+	impl<Address, Call, Signature, Extra> EncodeLike
+		for UncheckedExtrinsicV4<Address, Call, Signature, Extra>
+	where
+		Address: Encode,
+		Signature: Encode,
+		Call: Encode,
+		Extra: Encode,
+	{
+	}
+}
+
+#[cfg(test)]
 mod tests {
-	use super::*;
+	use super::{legacy::UncheckedExtrinsicV4, *};
+	use crate::traits::Lazy;
 	use sp_io::hashing::blake2_256;
 	use sp_runtime::{
 		codec::{Decode, Encode},
+		impl_tx_ext_default,
 		testing::TestSignature as TestSig,
-		traits::{DispatchInfoOf, IdentityLookup, Lazy, SignedExtension, Verify},
+		traits::{FakeDispatchable, IdentityLookup, TransactionExtension, Verify},
 	};
 
 	type TestContext = IdentityLookup<u64>;
 	type TestAccountId = u64;
-	type TestCall = Vec<u8>;
+	type TestCall = FakeDispatchable<Vec<u8>>;
 
 	impl VerifyMut for TestSig {
 		type Signer = <TestSig as Verify>::Signer;
@@ -447,42 +757,29 @@ mod tests {
 
 	// NOTE: this is demonstration. One can simply use `()` for testing.
 	#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, Ord, PartialOrd, TypeInfo)]
-	struct TestExtra;
-	impl SignedExtension for TestExtra {
-		const IDENTIFIER: &'static str = "TestExtra";
-		type AccountId = u64;
-		type Call = ();
-		type AdditionalSigned = ();
+	struct DummyExtension;
+	impl TransactionExtension<TestCall> for DummyExtension {
+		const IDENTIFIER: &'static str = "DummyExtension";
+		type Implicit = ();
+		type Val = ();
 		type Pre = ();
-
-		fn additional_signed(&self) -> core::result::Result<(), TransactionValidityError> {
-			Ok(())
-		}
-
-		fn pre_dispatch(
-			self,
-			who: &Self::AccountId,
-			call: &Self::Call,
-			info: &DispatchInfoOf<Self::Call>,
-			len: usize,
-		) -> Result<Self::Pre, TransactionValidityError> {
-			self.validate(who, call, info, len).map(|_| ())
-		}
+		impl_tx_ext_default!(TestCall; weight validate prepare);
 	}
 
-	type Ex = UncheckedExtrinsic<TestAccountId, TestCall, TestSig, TestExtra>;
-	type CEx = CheckedExtrinsic<TestAccountId, TestCall, TestExtra>;
+	type Ex = UncheckedExtrinsic<TestAccountId, TestCall, TestSig, DummyExtension>;
+	type CEx = CheckedExtrinsic<TestAccountId, TestCall, DummyExtension>;
 
 	#[test]
 	fn unsigned_codec_should_work() {
-		let ux = Ex::new_unsigned(vec![0u8; 0]);
+		let call: TestCall = vec![0u8; 0].into();
+		let ux = Ex::new_bare(call);
 		let encoded = ux.encode();
 		assert_eq!(Ex::decode(&mut &encoded[..]), Ok(ux));
 	}
 
 	#[test]
 	fn invalid_length_prefix_is_detected() {
-		let ux = Ex::new_unsigned(vec![0u8; 0]);
+		let ux = Ex::new_bare(vec![0u8; 0].into());
 		let mut encoded = ux.encode();
 
 		let length = Compact::<u32>::decode(&mut &encoded[..]).unwrap();
@@ -492,12 +789,19 @@ mod tests {
 	}
 
 	#[test]
+	fn transaction_codec_should_work() {
+		let ux = Ex::new_transaction(vec![0u8; 0].into(), DummyExtension);
+		let encoded = ux.encode();
+		assert_eq!(Ex::decode(&mut &encoded[..]), Ok(ux));
+	}
+
+	#[test]
 	fn signed_codec_should_work() {
 		let ux = Ex::new_signed(
-			vec![0u8; 0],
+			vec![0u8; 0].into(),
 			TEST_ACCOUNT,
-			TestSig(TEST_ACCOUNT, (vec![0u8; 0], TestExtra).encode()),
-			TestExtra,
+			TestSig(TEST_ACCOUNT, (vec![0u8; 0], DummyExtension).encode()),
+			DummyExtension,
 		);
 		let encoded = ux.encode();
 		assert_eq!(Ex::decode(&mut &encoded[..]), Ok(ux));
@@ -506,13 +810,13 @@ mod tests {
 	#[test]
 	fn large_signed_codec_should_work() {
 		let ux = Ex::new_signed(
-			vec![0u8; 0],
+			vec![0u8; 0].into(),
 			TEST_ACCOUNT,
 			TestSig(
 				TEST_ACCOUNT,
-				(vec![0u8; 257], TestExtra).using_encoded(blake2_256)[..].to_owned(),
+				(vec![0u8; 257], DummyExtension).using_encoded(blake2_256)[..].to_owned(),
 			),
-			TestExtra,
+			DummyExtension,
 		);
 		let encoded = ux.encode();
 		assert_eq!(Ex::decode(&mut &encoded[..]), Ok(ux));
@@ -520,20 +824,23 @@ mod tests {
 
 	#[test]
 	fn unsigned_check_should_work() {
-		let ux = Ex::new_unsigned(vec![0u8; 0]);
-		assert!(!ux.is_signed().unwrap_or(false));
-		assert!(<Ex as Checkable<TestContext>>::check(ux, &Default::default()).is_ok());
+		let ux = Ex::new_bare(vec![0u8; 0].into());
+		assert!(ux.is_inherent());
+		assert_eq!(
+			<Ex as Checkable<TestContext>>::check(ux, &Default::default()),
+			Ok(CEx { format: ExtrinsicFormat::Bare, function: vec![0u8; 0].into() }),
+		);
 	}
 
 	#[test]
 	fn badly_signed_check_should_fail() {
 		let ux = Ex::new_signed(
-			vec![0u8; 0],
+			vec![0u8; 0].into(),
 			TEST_ACCOUNT,
-			TestSig(TEST_ACCOUNT, vec![0u8; 0]),
-			TestExtra,
+			TestSig(TEST_ACCOUNT, vec![0u8; 0].into()),
+			DummyExtension,
 		);
-		assert!(ux.is_signed().unwrap_or(false));
+		assert!(!ux.is_inherent());
 		assert_eq!(
 			<Ex as Checkable<TestContext>>::check(ux, &Default::default()),
 			Err(InvalidTransaction::BadProof.into()),
@@ -541,23 +848,44 @@ mod tests {
 	}
 
 	#[test]
-	fn signed_check_should_work() {
-		let ux = Ex::new_signed(
-			vec![0u8; 0],
-			TEST_ACCOUNT,
-			TestSig(TEST_ACCOUNT, (vec![0u8; 0], TestExtra).encode()),
-			TestExtra,
-		);
-		assert!(ux.is_signed().unwrap_or(false));
+	fn transaction_check_should_work() {
+		let ux = Ex::new_transaction(vec![0u8; 0].into(), DummyExtension);
+		assert!(!ux.is_inherent());
 		assert_eq!(
 			<Ex as Checkable<TestContext>>::check(ux, &Default::default()),
-			Ok(CEx { signed: Some((TEST_ACCOUNT, TestExtra)), function: vec![0u8; 0] }),
+			Ok(CEx {
+				format: ExtrinsicFormat::General(0, DummyExtension),
+				function: vec![0u8; 0].into()
+			}),
+		);
+	}
+
+	#[test]
+	fn signed_check_should_work() {
+		let sig_payload = SignedPayload::from_raw(
+			FakeDispatchable::from(vec![0u8; 0]),
+			DummyExtension,
+			DummyExtension.implicit().unwrap(),
+		);
+		let ux = Ex::new_signed(
+			vec![0u8; 0].into(),
+			TEST_ACCOUNT,
+			TestSig(TEST_ACCOUNT, sig_payload.encode()),
+			DummyExtension,
+		);
+		assert!(!ux.is_inherent());
+		assert_eq!(
+			<Ex as Checkable<TestContext>>::check(ux, &Default::default()),
+			Ok(CEx {
+				format: ExtrinsicFormat::Signed(TEST_ACCOUNT, DummyExtension),
+				function: vec![0u8; 0].into()
+			}),
 		);
 	}
 
 	#[test]
 	fn encoding_matches_vec() {
-		let ex = Ex::new_unsigned(vec![0u8; 0]);
+		let ex = Ex::new_bare(vec![0u8; 0].into());
 		let encoded = ex.encode();
 		let decoded = Ex::decode(&mut encoded.as_slice()).unwrap();
 		assert_eq!(decoded, ex);
@@ -567,7 +895,7 @@ mod tests {
 
 	#[test]
 	fn conversion_to_opaque() {
-		let ux = Ex::new_unsigned(vec![0u8; 0]);
+		let ux = Ex::new_bare(vec![0u8; 0].into());
 		let encoded = ux.encode();
 		let opaque: OpaqueExtrinsic = ux.into();
 		let opaque_encoded = opaque.encode();
@@ -576,10 +904,106 @@ mod tests {
 
 	#[test]
 	fn large_bad_prefix_should_work() {
-		let encoded = Compact::<u32>::from(u32::MAX).encode();
+		let encoded = (Compact::<u32>::from(u32::MAX), Preamble::<(), (), ()>::Bare(0)).encode();
+		assert!(Ex::decode(&mut &encoded[..]).is_err());
+	}
+
+	#[test]
+	fn legacy_short_signed_encode_decode() {
+		let call: TestCall = vec![0u8; 4].into();
+		let signed = TEST_ACCOUNT;
+		let extension = DummyExtension;
+		let implicit = extension.implicit().unwrap();
+		let legacy_signature = TestSig(TEST_ACCOUNT, (&call, &extension, &implicit).encode());
+
+		let old_ux =
+			UncheckedExtrinsicV4::<TestAccountId, TestCall, TestSig, DummyExtension>::new_signed(
+				call.clone(),
+				signed,
+				legacy_signature.clone(),
+				extension.clone(),
+			);
+
+		let encoded_old_ux = old_ux.encode();
+		let decoded_old_ux = Ex::decode(&mut &encoded_old_ux[..]).unwrap();
+
+		assert_eq!(decoded_old_ux.function, call);
 		assert_eq!(
-			Ex::decode(&mut &encoded[..]),
-			Err(Error::from("Not enough data to fill buffer"))
+			decoded_old_ux.preamble,
+			Preamble::Signed(signed, legacy_signature.clone(), extension.clone())
 		);
+
+		let new_ux =
+			Ex::new_signed(call.clone(), signed, legacy_signature.clone(), extension.clone());
+
+		let new_checked = new_ux.check(&IdentityLookup::<TestAccountId>::default()).unwrap();
+		let old_checked =
+			decoded_old_ux.check(&IdentityLookup::<TestAccountId>::default()).unwrap();
+		assert_eq!(new_checked, old_checked);
+	}
+
+	#[test]
+	fn legacy_long_signed_encode_decode() {
+		let call: TestCall = vec![0u8; 257].into();
+		let signed = TEST_ACCOUNT;
+		let extension = DummyExtension;
+		let implicit = extension.implicit().unwrap();
+		let signature = TestSig(
+			TEST_ACCOUNT,
+			blake2_256(&(&call, DummyExtension, &implicit).encode()[..]).to_vec(),
+		);
+
+		let old_ux =
+			UncheckedExtrinsicV4::<TestAccountId, TestCall, TestSig, DummyExtension>::new_signed(
+				call.clone(),
+				signed,
+				signature.clone(),
+				extension.clone(),
+			);
+
+		let encoded_old_ux = old_ux.encode();
+		let decoded_old_ux = Ex::decode(&mut &encoded_old_ux[..]).unwrap();
+
+		assert_eq!(decoded_old_ux.function, call);
+		assert_eq!(
+			decoded_old_ux.preamble,
+			Preamble::Signed(signed, signature.clone(), extension.clone())
+		);
+
+		let new_ux = Ex::new_signed(call.clone(), signed, signature.clone(), extension.clone());
+
+		let new_checked = new_ux.check(&IdentityLookup::<TestAccountId>::default()).unwrap();
+		let old_checked =
+			decoded_old_ux.check(&IdentityLookup::<TestAccountId>::default()).unwrap();
+		assert_eq!(new_checked, old_checked);
+	}
+
+	#[test]
+	fn legacy_unsigned_encode_decode() {
+		let call: TestCall = vec![0u8; 0].into();
+
+		let old_ux =
+			UncheckedExtrinsicV4::<TestAccountId, TestCall, TestSig, DummyExtension>::new_unsigned(
+				call.clone(),
+			);
+
+		let encoded_old_ux = old_ux.encode();
+		let decoded_old_ux = Ex::decode(&mut &encoded_old_ux[..]).unwrap();
+
+		assert_eq!(decoded_old_ux.function, call);
+		assert_eq!(decoded_old_ux.preamble, Preamble::Bare(LEGACY_EXTRINSIC_FORMAT_VERSION));
+
+		let new_legacy_ux = Ex::new_bare_legacy(call.clone());
+		assert_eq!(encoded_old_ux, new_legacy_ux.encode());
+
+		let new_ux = Ex::new_bare(call.clone());
+		let encoded_new_ux = new_ux.encode();
+		let decoded_new_ux = Ex::decode(&mut &encoded_new_ux[..]).unwrap();
+		assert_eq!(new_ux, decoded_new_ux);
+
+		let new_checked = new_ux.check(&IdentityLookup::<TestAccountId>::default()).unwrap();
+		let old_checked =
+			decoded_old_ux.check(&IdentityLookup::<TestAccountId>::default()).unwrap();
+		assert_eq!(new_checked, old_checked);
 	}
 }

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -837,7 +837,7 @@ mod tests {
 		let ux = Ex::new_signed(
 			vec![0u8; 0].into(),
 			TEST_ACCOUNT,
-			TestSig(TEST_ACCOUNT, vec![0u8; 0].into()),
+			TestSig(TEST_ACCOUNT, vec![0u8; 0]),
 			DummyExtension,
 		);
 		assert!(!ux.is_inherent());
@@ -862,11 +862,14 @@ mod tests {
 
 	#[test]
 	fn signed_check_should_work() {
-		let sig_payload = SignedPayload::from_raw(
-			FakeDispatchable::from(vec![0u8; 0]),
-			DummyExtension,
-			DummyExtension.implicit().unwrap(),
-		);
+		let sig_payload = {
+      DummyExtension.implicit().unwrap();
+      SignedPayload::from_raw(
+      			FakeDispatchable::from(vec![0u8; 0]),
+      			DummyExtension,
+      			(),
+      		)
+  };
 		let ux = Ex::new_signed(
 			vec![0u8; 0].into(),
 			TEST_ACCOUNT,
@@ -913,8 +916,8 @@ mod tests {
 		let call: TestCall = vec![0u8; 4].into();
 		let signed = TEST_ACCOUNT;
 		let extension = DummyExtension;
-		let implicit = extension.implicit().unwrap();
-		let legacy_signature = TestSig(TEST_ACCOUNT, (&call, &extension, &implicit).encode());
+		extension.implicit().unwrap();
+		let legacy_signature = TestSig(TEST_ACCOUNT, (&call, &extension, &()).encode());
 
 		let old_ux =
 			UncheckedExtrinsicV4::<TestAccountId, TestCall, TestSig, DummyExtension>::new_signed(
@@ -947,10 +950,10 @@ mod tests {
 		let call: TestCall = vec![0u8; 257].into();
 		let signed = TEST_ACCOUNT;
 		let extension = DummyExtension;
-		let implicit = extension.implicit().unwrap();
+		extension.implicit().unwrap();
 		let signature = TestSig(
 			TEST_ACCOUNT,
-			blake2_256(&(&call, DummyExtension, &implicit).encode()[..]).to_vec(),
+			blake2_256(&(&call, DummyExtension, &()).encode()[..]).to_vec(),
 		);
 
 		let old_ux =

--- a/primitives/runtime/src/self_contained/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/self_contained/unchecked_extrinsic.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // This file is part of Frontier.
 //
-// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// Copyright (c) 2017-2020 Parity Technologies (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 // limitations under the License.
 
 use crate::traits::VerifyMut;
-use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, GetDispatchInfo},
-	traits::ExtrinsicCall,
+	traits::{ExtrinsicCall, InherentBuilder, SignedTransactionBuilder},
 };
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
+	generic::{self, Preamble},
 	traits::{
-		self, Checkable, Extrinsic, ExtrinsicMetadata, IdentifyAccount, MaybeDisplay, Member,
-		SignedExtension,
+		self, Checkable, Dispatchable, ExtrinsicLike, ExtrinsicMetadata, IdentifyAccount,
+		MaybeDisplay, Member, TransactionExtension,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic, RuntimeDebug,
@@ -36,66 +37,53 @@ use fp_self_contained::{CheckedExtrinsic, CheckedSignature, SelfContainedCall};
 /// A extrinsic right from the external world. This is unchecked and so
 /// can contain a signature.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
-pub struct UncheckedExtrinsic<Address, Call, Signature, Extra: SignedExtension>(
-	pub crate::generic::UncheckedExtrinsic<Address, Call, Signature, Extra>,
+pub struct UncheckedExtrinsic<Address, Call, Signature, Extension>(
+	pub generic::UncheckedExtrinsic<Address, Call, Signature, Extension>,
 );
 
-impl<Address, Call, Signature, Extra: SignedExtension>
-	UncheckedExtrinsic<Address, Call, Signature, Extra>
-{
+impl<Address, Call, Signature, Extension> UncheckedExtrinsic<Address, Call, Signature, Extension> {
 	/// New instance of a signed extrinsic aka "transaction".
-	pub fn new_signed(function: Call, signed: Address, signature: Signature, extra: Extra) -> Self {
-		Self(crate::generic::UncheckedExtrinsic::new_signed(function, signed, signature, extra))
+	pub fn new_signed(
+		function: Call,
+		signed: Address,
+		signature: Signature,
+		tx_ext: Extension,
+	) -> Self {
+		Self(generic::UncheckedExtrinsic::new_signed(function, signed, signature, tx_ext))
 	}
 
 	/// New instance of an unsigned extrinsic aka "inherent".
-	pub fn new_unsigned(function: Call) -> Self {
-		Self(crate::generic::UncheckedExtrinsic::new_unsigned(function))
+	pub fn new_bare(function: Call) -> Self {
+		Self(generic::UncheckedExtrinsic::new_bare(function))
 	}
 }
 
-impl<Address, Call, Signature, Extra> Extrinsic
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
-where
-	Address: TypeInfo,
-	Call: SelfContainedCall + TypeInfo,
-	Signature: TypeInfo,
-	Extra: SignedExtension,
+impl<Address: TypeInfo, Call: TypeInfo, Signature: TypeInfo, Extension: TypeInfo> ExtrinsicLike
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 {
-	type Call = Call;
-
-	type SignaturePayload = (Address, Signature, Extra);
-
-	fn is_signed(&self) -> Option<bool> {
-		if self.0.function.is_self_contained() {
-			Some(true)
-		} else {
-			self.0.is_signed()
-		}
-	}
-
-	fn new(function: Call, signed_data: Option<Self::SignaturePayload>) -> Option<Self> {
-		crate::generic::UncheckedExtrinsic::new(function, signed_data).map(Self)
+	fn is_bare(&self) -> bool {
+		ExtrinsicLike::is_bare(&self.0)
 	}
 }
 
-impl<Address, AccountId, Call, Signature, Extra, Lookup> Checkable<Lookup>
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, AccountId, Call, Signature, Extension, Lookup> Checkable<Lookup>
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: Member + MaybeDisplay,
 	Call: Encode + Member + SelfContainedCall,
-	Signature: Member + VerifyMut,
+	Signature: Member + traits::Verify + VerifyMut,
+	<Signature as traits::Verify>::Signer: IdentifyAccount<AccountId = AccountId>,
 	<Signature as VerifyMut>::Signer: IdentifyAccount<AccountId = AccountId>,
-	Extra: SignedExtension<AccountId = AccountId>,
+	Extension: Encode + TransactionExtension<Call>,
 	AccountId: Member + MaybeDisplay,
 	Lookup: traits::Lookup<Source = Address, Target = AccountId>,
 {
 	type Checked =
-		CheckedExtrinsic<AccountId, Call, Extra, <Call as SelfContainedCall>::SignedInfo>;
+		CheckedExtrinsic<AccountId, Call, Extension, <Call as SelfContainedCall>::SignedInfo>;
 
 	fn check(self, lookup: &Lookup) -> Result<Self::Checked, TransactionValidityError> {
 		if self.0.function.is_self_contained() {
-			if self.0.signature.is_some() {
+			if matches!(self.0.preamble, Preamble::Signed(_, _, _)) {
 				return Err(TransactionValidityError::Invalid(InvalidTransaction::BadProof));
 			}
 
@@ -111,10 +99,7 @@ where
 		} else {
 			let checked = Checkable::<Lookup>::check(self.0, lookup)?;
 			Ok(CheckedExtrinsic {
-				signed: match checked.signed {
-					Some((id, extra)) => CheckedSignature::Signed(id, extra),
-					None => CheckedSignature::Unsigned,
-				},
+				signed: CheckedSignature::GenericDelegated(checked.format),
 				function: checked.function,
 			})
 		}
@@ -125,17 +110,18 @@ where
 		self,
 		lookup: &Lookup,
 	) -> Result<Self::Checked, TransactionValidityError> {
+		use generic::ExtrinsicFormat;
 		if self.0.function.is_self_contained() {
 			match self.0.function.check_self_contained() {
 				Some(signed_info) => Ok(CheckedExtrinsic {
 					signed: match signed_info {
 						Ok(info) => CheckedSignature::SelfContained(info),
-						_ => CheckedSignature::Unsigned,
+						_ => CheckedSignature::GenericDelegated(ExtrinsicFormat::Bare),
 					},
 					function: self.0.function,
 				}),
 				None => Ok(CheckedExtrinsic {
-					signed: CheckedSignature::Unsigned,
+					signed: CheckedSignature::GenericDelegated(ExtrinsicFormat::Bare),
 					function: self.0.function,
 				}),
 			}
@@ -143,42 +129,44 @@ where
 			let checked =
 				Checkable::<Lookup>::unchecked_into_checked_i_know_what_i_am_doing(self.0, lookup)?;
 			Ok(CheckedExtrinsic {
-				signed: match checked.signed {
-					Some((id, extra)) => CheckedSignature::Signed(id, extra),
-					None => CheckedSignature::Unsigned,
-				},
+				signed: CheckedSignature::GenericDelegated(checked.format),
 				function: checked.function,
 			})
 		}
 	}
 }
 
-impl<Address, Call, Signature, Extra> ExtrinsicMetadata
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> ExtrinsicMetadata
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
-	Extra: SignedExtension,
+	Call: Dispatchable,
+	Extension: TransactionExtension<Call>,
 {
-	const VERSION: u8 = <crate::generic::UncheckedExtrinsic<Address, Call, Signature, Extra> as ExtrinsicMetadata>::VERSION;
-	type SignedExtensions = Extra;
+	const VERSIONS: &'static [u8] =
+		generic::UncheckedExtrinsic::<Address, Call, Signature, Extension>::VERSIONS;
+	type TransactionExtensions = Extension;
 }
 
-impl<Address, Call, Signature, Extra> ExtrinsicCall
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> ExtrinsicCall
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: TypeInfo,
-	Call: SelfContainedCall + TypeInfo,
+	Call: TypeInfo,
 	Signature: TypeInfo,
-	Extra: SignedExtension,
+	Extension: TypeInfo,
 {
+	type Call = Call;
+
 	fn call(&self) -> &Self::Call {
 		&self.0.function
 	}
 }
 
-impl<Address, Call: GetDispatchInfo, Signature, Extra> GetDispatchInfo
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extension> GetDispatchInfo
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
-	Extra: SignedExtension,
+	Call: GetDispatchInfo + Dispatchable,
+	Extension: TransactionExtension<Call>,
 {
 	fn get_dispatch_info(&self) -> DispatchInfo {
 		self.0.function.get_dispatch_info()
@@ -186,8 +174,11 @@ where
 }
 
 #[cfg(feature = "serde")]
-impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> serde::Serialize
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address: Encode, Signature: Encode, Call, Extension> serde::Serialize
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
+where
+	Call: Encode + Dispatchable,
+	Extension: Encode + TransactionExtension<Call>,
 {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error>
 	where
@@ -198,27 +189,74 @@ impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> s
 }
 
 #[cfg(feature = "serde")]
-impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtension>
-	serde::Deserialize<'a> for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<'a, Address: Decode, Signature: Decode, Call, Extension> serde::Deserialize<'a>
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
+where
+	Call: Decode + Dispatchable,
+	Extension: Decode + TransactionExtension<Call>,
 {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'a>,
 	{
-		<crate::generic::UncheckedExtrinsic<Address, Call, Signature, Extra>>::deserialize(de)
+		<generic::UncheckedExtrinsic<Address, Call, Signature, Extension>>::deserialize(de)
 			.map(Self)
 	}
 }
 
-impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Signature, Extra>>
-	for OpaqueExtrinsic
+impl<Address, Signature, Call, Extension> SignedTransactionBuilder
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
+where
+	Address: TypeInfo,
+	Signature: TypeInfo,
+	Call: TypeInfo,
+	Extension: TypeInfo,
+{
+	type Address = Address;
+	type Signature = Signature;
+	type Extension = Extension;
+
+	fn new_signed_transaction(
+		call: Self::Call,
+		signed: Address,
+		signature: Signature,
+		tx_ext: Extension,
+	) -> Self {
+		generic::UncheckedExtrinsic::new_signed(call, signed, signature, tx_ext).into()
+	}
+}
+
+impl<Address, Signature, Call, Extension> InherentBuilder
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
+where
+	Address: TypeInfo,
+	Signature: TypeInfo,
+	Call: TypeInfo,
+	Extension: TypeInfo,
+{
+	fn new_inherent(call: Self::Call) -> Self {
+		generic::UncheckedExtrinsic::new_bare(call).into()
+	}
+}
+
+impl<Address, Call, Signature, Extension>
+	From<UncheckedExtrinsic<Address, Call, Signature, Extension>> for OpaqueExtrinsic
 where
 	Address: Encode,
 	Signature: Encode,
 	Call: Encode,
-	Extra: SignedExtension,
+	Extension: Encode,
 {
-	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
+	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extension>) -> Self {
 		extrinsic.0.into()
+	}
+}
+
+impl<Address, Call, Signature, Extension>
+	From<generic::UncheckedExtrinsic<Address, Call, Signature, Extension>>
+	for UncheckedExtrinsic<Address, Call, Signature, Extension>
+{
+	fn from(utx: generic::UncheckedExtrinsic<Address, Call, Signature, Extension>) -> Self {
+		Self(utx)
 	}
 }

--- a/vendor/composable/cosmwasm/rpc/Cargo.toml
+++ b/vendor/composable/cosmwasm/rpc/Cargo.toml
@@ -11,18 +11,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # substrate primitives
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409" }
+sp-api = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 # local
 cosmwasm-runtime-api = { workspace = true }
 
 # SCALE
-codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = [
-    "derive",
-] }
+codec = { workspace = true, features = ["derive"] }
 
 # rpc
-jsonrpsee = { version = "0.24", features = ["client", "server", "macros"] }
+jsonrpsee = { workspace = true, features = ["client", "server", "macros"] }

--- a/vendor/composable/cosmwasm/runtime-api/Cargo.toml
+++ b/vendor/composable/cosmwasm/runtime-api/Cargo.toml
@@ -10,10 +10,8 @@ version = "1.0.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = [
-    "derive",
-] }
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2409", default-features = false }
+codec = { workspace = true, features = ["derive"] }
+sp-api = { workspace = true }
 
 [features]
 default = ["std"]

--- a/vendor/moonbeam/precompiles/assets-erc20/Cargo.toml
+++ b/vendor/moonbeam/precompiles/assets-erc20/Cargo.toml
@@ -23,9 +23,9 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, features = ["forbid-evm-reentrancy"] }
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true, features = ["forbid-evm-reentrancy"] }
+precompile-utils = { workspace = true }
 
 # Moonkit
 #moonkit-xcm-primitives = { workspace = true }
@@ -37,7 +37,7 @@ serde = { workspace = true, default-features = true }
 sha3 = { workspace = true, default-features = true }
 
 # Moonbeam
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", features = ["testing"] }
+precompile-utils = { workspace = true, default-features = true, features = ["testing"] }
 
 [features]
 default = ["std"]

--- a/vendor/moonbeam/precompiles/assets-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/mock.rs
@@ -106,6 +106,7 @@ impl frame_system::Config for Runtime {
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
+	type ExtensionsWeightInfo = ();
 }
 
 parameter_types! {
@@ -137,6 +138,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<

--- a/vendor/moonbeam/precompiles/assets-erc20/src/tests.rs
+++ b/vendor/moonbeam/precompiles/assets-erc20/src/tests.rs
@@ -234,7 +234,7 @@ fn approve() {
 					ForeignAssetId(0u128),
 					ForeignPCall::approve { spender: Address(Bob.into()), value: 500.into() },
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -272,7 +272,7 @@ fn approve_saturating() {
 					ForeignAssetId(0u128),
 					ForeignPCall::approve { spender: Address(Bob.into()), value: U256::MAX },
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -395,7 +395,7 @@ fn transfer() {
 					ForeignAssetId(0u128),
 					ForeignPCall::transfer { to: Address(Bob.into()), value: 400.into() },
 				)
-				.expect_cost(44795756) // 1 weight => 1 gas in mock
+				.expect_cost(50509756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -507,7 +507,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(66146756) // 1 weight => 1 gas in mock
+				.expect_cost(70172756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -576,7 +576,7 @@ fn transfer_from_non_incremental_approval() {
 					ForeignAssetId(0u128),
 					ForeignPCall::approve { spender: Address(Bob.into()), value: 500.into() },
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -596,7 +596,7 @@ fn transfer_from_non_incremental_approval() {
 					ForeignAssetId(0u128),
 					ForeignPCall::approve { spender: Address(Bob.into()), value: 300.into() },
 				)
-				.expect_cost(65259756)
+				.expect_cost(76042756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -702,7 +702,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(44795756) // 1 weight => 1 gas in mock
+				.expect_cost(50509756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -839,7 +839,7 @@ fn permit_valid() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -944,7 +944,7 @@ fn permit_valid_named_asset() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -1408,7 +1408,7 @@ fn permit_valid_with_metamask_signed_data() {
 						s: H256::from(s_real),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(1u128),
 					SELECTOR_LOG_APPROVAL,

--- a/vendor/moonbeam/precompiles/balances-erc20/Cargo.toml
+++ b/vendor/moonbeam/precompiles/balances-erc20/Cargo.toml
@@ -22,9 +22,9 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
-pallet-evm = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false, features = ["forbid-evm-reentrancy"] }
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", default-features = false }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true, features = ["forbid-evm-reentrancy"] }
+precompile-utils = { workspace = true }
 
 [dev-dependencies]
 hex-literal = { workspace = true }
@@ -33,7 +33,7 @@ serde = { workspace = true, default-features = true }
 sha3 = { workspace = true, default-features = true }
 
 # Moonbeam
-precompile-utils = { git = "https://github.com/noirhq/frontier", branch = "stable2409", features = ["testing"] }
+precompile-utils = { workspace = true, default-features = true, features = ["testing"] }
 
 scale-info = { workspace = true, default-features = true, features = ["derive"] }
 

--- a/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
@@ -66,6 +66,7 @@ impl frame_system::Config for Runtime {
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
+	type ExtensionsWeightInfo = ();
 }
 
 parameter_types! {
@@ -97,6 +98,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> =

--- a/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/mock.rs
@@ -21,7 +21,7 @@ use super::*;
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot, FrameSystemAccountProvider};
 use precompile_utils::{precompile_set::*, testing::MockAccount};
-use sp_core::{ConstU32, H256, U256};
+use sp_core::{H256, U256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,

--- a/vendor/moonbeam/precompiles/balances-erc20/src/tests.rs
+++ b/vendor/moonbeam/precompiles/balances-erc20/src/tests.rs
@@ -261,7 +261,7 @@ fn transfer() {
 					Precompile1,
 					PCall::transfer { to: Address(Bob.into()), value: 400.into() },
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -336,7 +336,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -426,7 +426,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,


### PR DESCRIPTION
This PR bumps Polkadot SDK to `stable2412`.